### PR TITLE
Clearer installer menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ I recorded a walkthrough [video](https://www.youtube.com/watch?v=zAbAf5-H5Yo) fo
 
 1. Install [Raspberry Pi OS (lite)](https://www.raspberrypi.com/software/) onto an SD card.
 
-2. Copy over a Mac OS disk image and a ROM file — the installer auto-discovers them in `$HOME`. It offers two emulators (it defaults to **BasiliskII**):
+2. Copy over a Mac OS disk image and a ROM file — the installer auto-discovers them in `$HOME`. It offers two emulators (it defaults to **Basilisk II**):
 
-   - **BasiliskII** — a 68k Mac running System 7. On the Pi Zero 2 W this is the fastest option. Needs a **512 KB or 1 MB 68k ROM** (Mac IIci / Quadra, try searching online for `064DC91D`) and a disk image.
+   - **Basilisk II** — a 68k Mac running System 7. On the Pi Zero 2 W this is the fastest option. Needs a **512 KB or 1 MB 68k ROM** (Mac IIci / Quadra, try searching online for `064DC91D`) and a disk image.
    - **SheepShaver** — if you want PowerPC running Mac OS 8.1+. Needs the **4 MB PowerPC [ROM](https://www.redundantrobot.com/sheepshaver)** and a disk image. Choose this only if you need PPC-era software as it's **very slow on a Pi Zero**.
 
    Rename your ROM file `ROM` (no file extension)
@@ -54,13 +54,13 @@ Once installed the Pi boots straight into the Mac. A few controls:
 - **`macintosh`** — run this from the prompt to boot the Mac again.
 - **Networking** works out of the box (slirp NAT). In the Mac, set TCP/IP to **DHCP**.
 
-Re-run the installer any time to **update** an existing install — it keeps your disk image and settings. To **switch emulator**, pick the other one (BasiliskII ⇄ SheepShaver); each core's prefs are preserved.
+Re-run the installer any time to **update** an existing install — it keeps your disk image and settings. To **switch emulator**, pick the other one (Basilisk II ⇄ SheepShaver); each core's prefs are preserved.
 
 ## The software: manual install
 
 You can also do everything the script does by yourself: 
 - [Maclock hardware guide](https://github.com/wr/macintosh-mini/tree/main/maclock-build)
-- [BasiliskII install guide](https://github.com/wr/macintosh-mini/blob/main/emulators/BasiliskII.md)
+- [Basilisk II install guide](https://github.com/wr/macintosh-mini/blob/main/emulators/BasiliskII.md)
 - [SheepShaver install guide](https://github.com/wr/macintosh-mini/blob/main/emulators/SheepShaver.md).
 
 

--- a/emulators/BasiliskII.md
+++ b/emulators/BasiliskII.md
@@ -1,14 +1,14 @@
-# BasiliskII on Raspberry Pi Zero 2 W
+# Basilisk II on Raspberry Pi Zero 2 W
 
-This guide covers the software side: getting BasiliskII (a 68k classic Mac emulator) to run on the Pi Zero. The [hardware build](../maclock-build) is a separate guide.
+This guide covers the software side: getting Basilisk II (a 68k classic Mac emulator) to run on the Pi Zero. The [hardware build](../maclock-build) is a separate guide.
 
-> BasiliskII (68k) is the [setup script](../setup.sh) default and the fastest option on the Pi Zero — a 68k guest is far lighter to interpret than PowerPC. For PowerPC software (Mac OS 8.5+), see the [SheepShaver guide](./SheepShaver.md) instead.
+> Basilisk II (68k) is the [setup script](../setup.sh) default and the fastest option on the Pi Zero — a 68k guest is far lighter to interpret than PowerPC. For PowerPC software (Mac OS 8.5+), see the [SheepShaver guide](./SheepShaver.md) instead.
 
 > [!NOTE]
 > **Tested environment**
 > - **Hardware:** Raspberry Pi Zero 2 W (aarch64, ~416 MB RAM)
 > - **OS:** Raspberry Pi OS Lite, 64-bit (Trixie) kernel `6.12`
-> - **BasiliskII:** `kanjitalk755/macemu` HEAD. Don't pin to `v1.0.0` — it predates aarch64 support.
+> - **Basilisk II:** `kanjitalk755/macemu` HEAD. Don't pin to `v1.0.0` — it predates aarch64 support.
 
 
 ## Quick install
@@ -41,7 +41,7 @@ sudo apt install -y \
   git
 ```
 
-`libmpfr-dev` is required — BasiliskII emulates the 68k FPU with MPFR.
+`libmpfr-dev` is required — Basilisk II emulates the 68k FPU with MPFR.
 
 Enable the seat manager and add yourself to the right groups. The seatd group is `seat` on some distros and `_seatd` on Debian Trixie — adjust if `seat` doesn't exist:
 
@@ -54,7 +54,7 @@ Log out and back in (or reboot) so the new group memberships take effect.
 
 ### 2. Kernel setting (sysctl)
 
-BasiliskII maps the Mac low-memory globals at address `0x0`, so it needs `mmap_min_addr=0` — and it must be active **before** running `./autogen.sh` (configure's SIGSEGV-recovery probe needs it too):
+Basilisk II maps the Mac low-memory globals at address `0x0`, so it needs `mmap_min_addr=0` — and it must be active **before** running `./autogen.sh` (configure's SIGSEGV-recovery probe needs it too):
 
 ```bash
 sudo tee /etc/sysctl.d/60-basilisk.conf <<'EOF'
@@ -63,9 +63,9 @@ EOF
 sudo sysctl --system
 ```
 
-(Unlike SheepShaver, BasiliskII doesn't need `vm.overcommit_memory=1` — it has no large upfront reservation.)
+(Unlike SheepShaver, Basilisk II doesn't need `vm.overcommit_memory=1` — it has no large upfront reservation.)
 
-### 3. Build BasiliskII
+### 3. Build Basilisk II
 
 ```bash
 cd ~
@@ -78,9 +78,9 @@ make -j"$(nproc)"
 sudo install -m755 BasiliskII /usr/local/bin/BasiliskII
 ```
 
-- The JIT is x86-only, so on ARM BasiliskII runs as an interpreter — `--disable-jit-compiler` is correct.
+- The JIT is x86-only, so on ARM Basilisk II runs as an interpreter — `--disable-jit-compiler` is correct.
 - `--enable-vosf` re-blits only the changed parts of the screen (snappier UI); stable on this Pi.
-- No `-DMEM_BULK` needed — that's a SheepShaver-on-aarch64 fix; BasiliskII uses `DIRECT_ADDRESSING` here out of the box.
+- No `-DMEM_BULK` needed — that's a SheepShaver-on-aarch64 fix; Basilisk II uses `DIRECT_ADDRESSING` here out of the box.
 - `-mcpu=cortex-a53` is a small Pi Zero 2 W win.
 - Low on RAM? Use `make -j2` — four parallel compiles can OOM on a 512 MB Pi.
 
@@ -136,7 +136,7 @@ sudo install -m644 crash.wav /usr/local/bin/crash.wav
 sudo install -m755 basilisk.sh /usr/local/bin/basilisk.sh
 ```
 
-### 5. BasiliskII preferences
+### 5. Basilisk II preferences
 
 ```sh
 nano ~/.basilisk_ii_prefs
@@ -177,7 +177,7 @@ EOF
 sudo systemctl daemon-reload
 ```
 
-### 7. Auto-launch BasiliskII on `tty1`
+### 7. Auto-launch Basilisk II on `tty1`
 
 ```bash
 cat >> ~/.profile <<'EOF'

--- a/emulators/README.md
+++ b/emulators/README.md
@@ -1,8 +1,8 @@
 # Emulators
 
-Two ways to run classic Mac OS on the Pi. The [setup script](../setup.sh) installs **BasiliskII** by default.
+Two ways to run classic Mac OS on the Pi. The [setup script](../setup.sh) installs **Basilisk II** by default.
 
-- **[BasiliskII](./BasiliskII.md)** — 68k Mac (System 7 / Mac OS 8.1). Fastest on the Pi Zero.
+- **[Basilisk II](./BasiliskII.md)** — 68k Mac (System 7 / Mac OS 8.1). Fastest on the Pi Zero.
 - **[SheepShaver](./SheepShaver.md)** — PowerPC Mac (Mac OS 8.1+). Slower; use it only if you need PPC-era software.
 
 `chimes/` holds the startup and crash sounds both guides pull from.

--- a/emulators/SheepShaver.md
+++ b/emulators/SheepShaver.md
@@ -2,7 +2,7 @@
 
 This guide covers the software side: getting SheepShaver (a classic Mac emulator) to run on the Pi Zero. The [hardware build](../maclock-build) is a separate guide.
 
-> SheepShaver runs PowerPC Mac OS (8.1+) and is **slow** on the Pi Zero. **BasiliskII** (68k) is the [setup script](../setup.sh) default and much faster (see the [BasiliskII guide](./BasiliskII.md)) — use this guide only if you specifically need PPC-era software.
+> SheepShaver runs PowerPC Mac OS (8.1+) and is **slow** on the Pi Zero. **Basilisk II** (68k) is the [setup script](../setup.sh) default and much faster (see the [Basilisk II guide](./BasiliskII.md)) — use this guide only if you specifically need PPC-era software.
 
 > [!NOTE]
 > **Tested environment**

--- a/maclock-build/README.md
+++ b/maclock-build/README.md
@@ -151,7 +151,7 @@ sudo systemctl enable --now brightness-control button-handler
 
 ### 4. Install the emulator
 
-The hardware side of the maclock is now done. The [setup script](../setup.sh) installs **BasiliskII**; manual build steps are in the [BasiliskII guide](../emulators/BasiliskII.md) (or the [SheepShaver guide](../emulators/SheepShaver.md) for PowerPC).
+The hardware side of the maclock is now done. The [setup script](../setup.sh) installs **Basilisk II**; manual build steps are in the [Basilisk II guide](../emulators/BasiliskII.md) (or the [SheepShaver guide](../emulators/SheepShaver.md) for PowerPC).
 
 ---
 

--- a/setup.sh
+++ b/setup.sh
@@ -428,6 +428,79 @@ crash_for_chime() {
 }
 CRASH_NAME=$(crash_for_chime "$CHIME_NAME")
 
+# --- Reconfigure an existing install ---------------------------------------
+# When prefs already exist for the chosen emulator, offer to keep them or
+# change individual settings in place (instead of silently keeping them).
+pref_get() { sed -n "s/^$2 //p" "$1" 2>/dev/null | head -1; }
+pref_set() {
+  if grep -q "^$2 " "$1" 2>/dev/null; then sed -i "s#^$2 .*#$2 $3#" "$1"
+  else printf '%s %s\n' "$2" "$3" >> "$1"; fi
+}
+
+reconf_disk() {   # $1=prefs  $2=is_basilisk
+  local img p; local args=() paths=()
+  shopt -s nullglob
+  if [[ $2 -eq 1 ]]; then paths=("$HOME"/*.hda "$HOME"/*.dsk); else paths=("$HOME"/*.hda); fi
+  shopt -u nullglob
+  if [[ ${#paths[@]} -eq 0 ]]; then
+    whiptail --backtitle "macintosh-mini" --msgbox "No disk image in $HOME — copy one over first." 8 64 </dev/tty
+    return 0
+  fi
+  for p in "${paths[@]}"; do args+=("$(basename "$p")" "$(du -h "$p" | cut -f1)"); done
+  img=$(wt_menu "Disk image" "Pick the disk to boot:" "$(basename "${paths[0]}")" "${#paths[@]}" "${args[@]}") || return 0
+  if [[ $2 -eq 1 ]]; then pref_set "$1" disk "$HOME/$img"; else pref_set "$1" disk "$img"; fi
+}
+
+reconf_color() {  # $1=prefs  $2=is_basilisk
+  local mode depth
+  mode=$(wt_menu "Color depth" "Color depth:" "Color" 3 \
+    "Color" "16-bit" "Grayscale" "8-bit" "Black & White" "1-bit") || return 0
+  case "$mode" in "Color") depth=16 ;; "Grayscale") depth=8 ;; "Black & White") depth=1 ;; esac
+  if [[ $2 -eq 1 ]]; then pref_set "$1" displaycolordepth "$depth"
+  else sed -i "s#^\(screen .*\)/[0-9]*\$#\1/$depth#" "$1"; fi
+}
+
+reconf_chime() {
+  local tag name="" crash entry t d f; local args=()
+  for entry in "${CHIMES_DATA[@]}"; do IFS='|' read -r t d _ <<< "$entry"; args+=("$t" "$d"); done
+  tag=$(wt_menu "Boot chime" "Which startup chime?" "$DEFAULT_CHIME_TAG" 8 "${args[@]}") || return 0
+  for entry in "${CHIMES_DATA[@]}"; do IFS='|' read -r t _ f <<< "$entry"; [[ "$t" == "$tag" ]] && name=$f; done
+  [[ -n $name ]] || return 0
+  crash=$(crash_for_chime "$name")
+  curl -fL --retry 3 -o "$HOME/$CHIME_FILE" "$REPO_RAW/emulators/chimes/${name}.wav" \
+    && sudo install -m644 "$HOME/$CHIME_FILE" /usr/local/bin/chime.wav
+  curl -fL --retry 3 -o "$HOME/crash.wav" "$REPO_RAW/emulators/chimes/${crash}.wav" \
+    && sudo install -m644 "$HOME/crash.wav" /usr/local/bin/crash.wav
+  return 0
+}
+
+configure_existing() {  # $1=prefs  $2=is_basilisk  $3=emulator name
+  local prefs=$1 isb=$2 emu=$3 cur_disk cur_depth pick
+  while true; do
+    cur_disk=$(basename "$(pref_get "$prefs" disk)" 2>/dev/null)
+    if [[ $isb -eq 1 ]]; then cur_depth=$(pref_get "$prefs" displaycolordepth)
+    else cur_depth=$(pref_get "$prefs" screen | sed 's#.*/##'); fi
+    pick=$(wt_menu "$emu — already installed" \
+      "Keep your current settings, or change one:" "Keep" 4 \
+      "Keep"  "Keep existing settings (recommended)" \
+      "Disk"  "Change disk image   (now: ${cur_disk:-unknown})" \
+      "Chime" "Change startup chime" \
+      "Color" "Change color depth   (now: ${cur_depth:-?} bpp)") || break
+    case "$pick" in
+      Keep|"") break ;;
+      Disk)  reconf_disk  "$prefs" "$isb" || true ;;
+      Chime) reconf_chime              || true ;;
+      Color) reconf_color "$prefs" "$isb" || true ;;
+    esac
+  done
+}
+
+if [[ $NEED_PREFS -eq 0 && $INSTALL_BASILISK -eq 1 ]]; then
+  configure_existing "$HOME/.basilisk_ii_prefs" 1 "Basilisk II"
+elif [[ $NEED_PREFS -eq 0 && $INSTALL_SHEEPSHAVER -eq 1 ]]; then
+  configure_existing "$HOME/.sheepshaver_prefs" 0 "SheepShaver"
+fi
+
 # Performance optimizations
 if [[ -z $PERF ]]; then
   PERF_CHOICE=$(wt_menu "Performance" "Apply performance optimizations?" "Yes" 2 \

--- a/setup.sh
+++ b/setup.sh
@@ -164,7 +164,7 @@ wt_menu() {
   local total_height=$(( list_height + 8 ))
   whiptail --backtitle "macintosh-mini" --title "$title" \
     --default-item "$default" \
-    --menu "$prompt" "$total_height" 72 "$list_height" \
+    --menu "$prompt" "$total_height" 78 "$list_height" \
     "$@" 3>&1 1>&2 2>&3 </dev/tty
 }
 
@@ -319,18 +319,27 @@ ensure_whiptail
 
 # --- Whiptail prompts ------------------------------------------------------
 if [[ $INSTALL_MACLOCK -eq 0 && $INSTALL_SHEEPSHAVER -eq 0 && $INSTALL_BASILISK -eq 0 ]]; then
-  CHOICE=$(wt_menu "macintosh-mini" "What do you want to install?" "Both" 5 \
-    "Both"        "maclock + BasiliskII (68k, Mac OS 7)" \
-    "Both-PPC"    "maclock + SheepShaver (PowerPC, Mac OS 8.1+)" \
-    "maclock"     "hardware only (Waveshare display, dial, buttons)" \
-    "BasiliskII"  "68k emulator only (Mac OS 7)" \
-    "SheepShaver" "PowerPC emulator only (Mac OS 8.1+)") || die "Cancelled"
+  # Single-column menu (label = tag, blank item); the empty row separates the
+  # recommended default from the rest.
+  opt_full="BasiliskII emulator + Maclock hardware support (default, recommended)"
+  opt_ppc="SheepShaver emulator + Maclock hardware support (laggy)"
+  opt_hw="Maclock hardware support only"
+  opt_b2="BasiliskII emulator only"
+  opt_ss="SheepShaver emulator only"
+  CHOICE=$(wt_menu "macintosh-mini" "What do you want to install?" "$opt_full" 6 \
+    "$opt_full" "" \
+    "" "" \
+    "$opt_ppc" "" \
+    "$opt_hw" "" \
+    "$opt_b2" "" \
+    "$opt_ss" "") || die "Cancelled"
   case "$CHOICE" in
-    Both)        INSTALL_MACLOCK=1; INSTALL_BASILISK=1 ;;
-    Both-PPC)    INSTALL_MACLOCK=1; INSTALL_SHEEPSHAVER=1 ;;
-    maclock)     INSTALL_MACLOCK=1 ;;
-    BasiliskII)  INSTALL_BASILISK=1 ;;
-    SheepShaver) INSTALL_SHEEPSHAVER=1 ;;
+    "$opt_full") INSTALL_MACLOCK=1; INSTALL_BASILISK=1 ;;
+    "$opt_ppc")  INSTALL_MACLOCK=1; INSTALL_SHEEPSHAVER=1 ;;
+    "$opt_hw")   INSTALL_MACLOCK=1 ;;
+    "$opt_b2")   INSTALL_BASILISK=1 ;;
+    "$opt_ss")   INSTALL_SHEEPSHAVER=1 ;;
+    *)           die "Cancelled" ;;
   esac
   # User just chose an emulator via the menu — re-check assets now.
   [[ $INSTALL_SHEEPSHAVER -eq 1 ]] && check_sheepshaver_assets

--- a/setup.sh
+++ b/setup.sh
@@ -161,7 +161,8 @@ wt_menu() {
   # Args: title, prompt, default_tag, list_height, then pairs of tag/label.
   local title=$1 prompt=$2 default=$3 list_height=$4
   shift 4
-  local total_height=$(( list_height + 8 ))
+  local extra=8; [[ -z $prompt ]] && extra=7
+  local total_height=$(( list_height + extra ))
   whiptail --backtitle "macintosh-mini" --title "$title" \
     --default-item "$default" \
     --menu "$prompt" "$total_height" 78 "$list_height" \
@@ -319,16 +320,14 @@ ensure_whiptail
 
 # --- Whiptail prompts ------------------------------------------------------
 if [[ $INSTALL_MACLOCK -eq 0 && $INSTALL_SHEEPSHAVER -eq 0 && $INSTALL_BASILISK -eq 0 ]]; then
-  # Single-column menu (label = tag, blank item); the empty row separates the
-  # recommended default from the rest.
-  opt_full="Basilisk II emulator + Maclock hardware support (default, recommended)"
-  opt_ppc="SheepShaver emulator + Maclock hardware support (laggy)"
-  opt_hw="Maclock hardware support only"
-  opt_b2="Basilisk II emulator only"
-  opt_ss="SheepShaver emulator only"
-  CHOICE=$(wt_menu "macintosh-mini" "What do you want to install?" "$opt_full" 6 \
+  # Single-column menu (label = tag, blank item).
+  opt_full="Basilisk II + Maclock hardware (default)"
+  opt_ppc="SheepShaver + Maclock hardware (laggy)"
+  opt_hw="Maclock hardware only"
+  opt_b2="Basilisk II only"
+  opt_ss="SheepShaver only"
+  CHOICE=$(wt_menu "Macintosh Mini Installer" "" "$opt_full" 5 \
     "$opt_full" "" \
-    "" "" \
     "$opt_ppc" "" \
     "$opt_hw" "" \
     "$opt_b2" "" \
@@ -395,6 +394,7 @@ if [[ ($INSTALL_SHEEPSHAVER -eq 1 || $INSTALL_BASILISK -eq 1) && -z $CHIME_NAME 
   done
 fi
 [[ -z $CHIME_NAME ]] && CHIME_NAME=$DEFAULT_CHIME
+[[ -n ${CHIME_TAG:-} ]] && printf '%s\n' "$CHIME_TAG" > "$HOME/.macintosh_chime"
 
 # Color — BasiliskII defaults to 8-bit (lighter), SheepShaver to 16-bit.
 if [[ ($INSTALL_SHEEPSHAVER -eq 1 || $INSTALL_BASILISK -eq 1) && -z $COLOR_MODE && $NEED_PREFS -eq 1 ]]; then
@@ -466,6 +466,7 @@ reconf_chime() {
   tag=$(wt_menu "Boot chime" "Which startup chime?" "$DEFAULT_CHIME_TAG" 8 "${args[@]}") || return 0
   for entry in "${CHIMES_DATA[@]}"; do IFS='|' read -r t _ f <<< "$entry"; [[ "$t" == "$tag" ]] && name=$f; done
   [[ -n $name ]] || return 0
+  printf '%s\n' "$tag" > "$HOME/.macintosh_chime"
   crash=$(crash_for_chime "$name")
   curl -fL --retry 3 -o "$HOME/$CHIME_FILE" "$REPO_RAW/emulators/chimes/${name}.wav" \
     && sudo install -m644 "$HOME/$CHIME_FILE" /usr/local/bin/chime.wav
@@ -474,38 +475,42 @@ reconf_chime() {
   return 0
 }
 
-configure_existing() {  # $1=prefs  $2=is_basilisk  $3=emulator name
-  local prefs=$1 isb=$2 emu=$3 cur_disk cur_depth pick
+configure_existing() {  # $1=prefs  $2=is_basilisk
+  local prefs=$1 isb=$2 cur_disk cur_depth cur_chime pick
   while true; do
     cur_disk=$(basename "$(pref_get "$prefs" disk)" 2>/dev/null)
     if [[ $isb -eq 1 ]]; then cur_depth=$(pref_get "$prefs" displaycolordepth)
     else cur_depth=$(pref_get "$prefs" screen | sed 's#.*/##'); fi
-    pick=$(wt_menu "$emu — already installed" \
-      "Keep your current settings, or change one:" "Keep" 4 \
-      "Keep"  "Keep existing settings (recommended)" \
-      "Disk"  "Change disk image   (now: ${cur_disk:-unknown})" \
-      "Chime" "Change startup chime" \
-      "Color" "Change color depth   (now: ${cur_depth:-?} bpp)") || break
-    case "$pick" in
-      Keep|"") break ;;
-      Disk)  reconf_disk  "$prefs" "$isb" || true ;;
-      Chime) reconf_chime              || true ;;
-      Color) reconf_color "$prefs" "$isb" || true ;;
-    esac
+    cur_chime=$(cat "$HOME/.macintosh_chime" 2>/dev/null || true)
+    # OK = change the highlighted setting; Continue = proceed keeping settings.
+    if pick=$(whiptail --backtitle "macintosh-mini" --title "Emulator Settings" \
+        --ok-button "Change" --cancel-button "Continue" --menu "" 12 72 3 \
+        "Disk image"    "${cur_disk:-unknown}" \
+        "Startup chime" "${cur_chime:-—}" \
+        "Color depth"   "${cur_depth:-?}-bit" \
+        3>&1 1>&2 2>&3 </dev/tty); then
+      case "$pick" in
+        "Disk image")    reconf_disk  "$prefs" "$isb" || true ;;
+        "Startup chime") reconf_chime                 || true ;;
+        "Color depth")   reconf_color "$prefs" "$isb" || true ;;
+      esac
+    else
+      break
+    fi
   done
 }
 
 if [[ $NEED_PREFS -eq 0 && $INSTALL_BASILISK -eq 1 ]]; then
-  configure_existing "$HOME/.basilisk_ii_prefs" 1 "Basilisk II"
+  configure_existing "$HOME/.basilisk_ii_prefs" 1
 elif [[ $NEED_PREFS -eq 0 && $INSTALL_SHEEPSHAVER -eq 1 ]]; then
-  configure_existing "$HOME/.sheepshaver_prefs" 0 "SheepShaver"
+  configure_existing "$HOME/.sheepshaver_prefs" 0
 fi
 
 # Performance optimizations
 if [[ -z $PERF ]]; then
   PERF_CHOICE=$(wt_menu "Performance" "Apply performance optimizations?" "Yes" 2 \
-    "Yes"  "service masking, fsck skip, disable-bt, -mcpu=cortex-a53, 128MB RAM" \
-    "No"   "stock install") || die "Cancelled"
+    "Yes"  "128 MB RAM, leaner services, native build" \
+    "No"   "Stock install") || die "Cancelled"
   case "$PERF_CHOICE" in Yes) PERF=1 ;; No) PERF=0 ;; esac
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -476,23 +476,29 @@ reconf_chime() {
 }
 
 configure_existing() {  # $1=prefs  $2=is_basilisk
-  local prefs=$1 isb=$2 cur_disk cur_depth cur_chime pick
+  local prefs=$1 isb=$2 cur_disk cur_depth cur_chime cur_color pick
   while true; do
     cur_disk=$(basename "$(pref_get "$prefs" disk)" 2>/dev/null)
     if [[ $isb -eq 1 ]]; then cur_depth=$(pref_get "$prefs" displaycolordepth)
     else cur_depth=$(pref_get "$prefs" screen | sed 's#.*/##'); fi
     cur_chime=$(cat "$HOME/.macintosh_chime" 2>/dev/null || true)
+    case "${cur_depth:-}" in
+      16) cur_color="Color 16-bit" ;;
+      8)  cur_color="Grayscale 8-bit" ;;
+      1)  cur_color="Black & White 1-bit" ;;
+      *)  cur_color="${cur_depth:-?}-bit" ;;
+    esac
     # OK = change the highlighted setting; Continue = proceed keeping settings.
     if pick=$(whiptail --backtitle "macintosh-mini" --title "Emulator Settings" \
         --ok-button "Change" --cancel-button "Continue" --menu "" 12 72 3 \
-        "Disk image"    "${cur_disk:-unknown}" \
-        "Startup chime" "${cur_chime:-—}" \
-        "Color depth"   "${cur_depth:-?}-bit" \
+        "Disk image:"    "${cur_disk:-unknown}" \
+        "Startup chime:" "${cur_chime:-—}" \
+        "Color depth:"   "$cur_color" \
         3>&1 1>&2 2>&3 </dev/tty); then
       case "$pick" in
-        "Disk image")    reconf_disk  "$prefs" "$isb" || true ;;
-        "Startup chime") reconf_chime                 || true ;;
-        "Color depth")   reconf_color "$prefs" "$isb" || true ;;
+        "Disk image:")    reconf_disk  "$prefs" "$isb" || true ;;
+        "Startup chime:") reconf_chime                 || true ;;
+        "Color depth:")   reconf_color "$prefs" "$isb" || true ;;
       esac
     else
       break
@@ -508,8 +514,8 @@ fi
 
 # Performance optimizations
 if [[ -z $PERF ]]; then
-  PERF_CHOICE=$(wt_menu "Performance" "Apply performance optimizations?" "Yes" 2 \
-    "Yes"  "128 MB RAM, leaner services, native build" \
+  PERF_CHOICE=$(wt_menu "Performance Optimizations" "" "Yes" 2 \
+    "Yes"  "Faster — more RAM, fewer background services" \
     "No"   "Stock install") || die "Cancelled"
   case "$PERF_CHOICE" in Yes) PERF=1 ;; No) PERF=0 ;; esac
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -321,10 +321,10 @@ ensure_whiptail
 if [[ $INSTALL_MACLOCK -eq 0 && $INSTALL_SHEEPSHAVER -eq 0 && $INSTALL_BASILISK -eq 0 ]]; then
   # Single-column menu (label = tag, blank item); the empty row separates the
   # recommended default from the rest.
-  opt_full="BasiliskII emulator + Maclock hardware support (default, recommended)"
+  opt_full="Basilisk II emulator + Maclock hardware support (default, recommended)"
   opt_ppc="SheepShaver emulator + Maclock hardware support (laggy)"
   opt_hw="Maclock hardware support only"
-  opt_b2="BasiliskII emulator only"
+  opt_b2="Basilisk II emulator only"
   opt_ss="SheepShaver emulator only"
   CHOICE=$(wt_menu "macintosh-mini" "What do you want to install?" "$opt_full" 6 \
     "$opt_full" "" \


### PR DESCRIPTION
## Summary
The first install prompt defaulted to **"Both"**, which didn't say both-of-what. This relabels every option to state exactly what it installs, with a blank row setting the recommended default apart:

```
What do you want to install?

   BasiliskII emulator + Maclock hardware support (default, recommended)

   SheepShaver emulator + Maclock hardware support (laggy)
   Maclock hardware support only
   BasiliskII emulator only
   SheepShaver emulator only
```

Menu box widened (72→78) so the longer labels fit. Follow-up to the merged W-247 work.

## Test plan
- [ ] Run `setup.sh` interactively → the menu shows the labels above with a blank line after the recommended option.
- [ ] Selecting each option installs the right combo (hardware/emulator).
- [ ] Esc/Cancel (or the blank row) exits cleanly with "Cancelled".

Refs W-269