### PR TITLE
Add pantry quick-reorder terminal (ESP32-S3 + LVGL touchscreen)

### DIFF
--- a/pantry-terminal/.gitignore
+++ b/pantry-terminal/.gitignore
@@ -1,0 +1,11 @@
+# Secrets: Wi-Fi password + Amazon session cookies. NEVER commit this.
+src/secrets.h
+
+# PlatformIO build output
+.pio/
+.pioenvs/
+.piolibdeps/
+
+# IDE
+.vscode/
+.idea/

--- a/pantry-terminal/README.md
+++ b/pantry-terminal/README.md
@@ -1,0 +1,132 @@
+# Pantry Reorder Terminal
+
+A tiny touchscreen that lives in your pantry. Tap **Toilet Paper**, **Paper
+Towels**, **Soap**, **Laundry Detergent**… and the item drops straight into your
+real Amazon cart. Open the Amazon app, tap Buy, done.
+
+Runs on an **ESP32-S3 + a small LVGL touchscreen** — no Raspberry Pi, no server
+of your own, no cloud middleman.
+
+## How it actually works (and the honest caveats)
+
+There is **no official API for placing orders on a personal Amazon account.**
+Amazon's Dash Replenishment is gated to appliance makers, the Product
+Advertising API only builds links, and the Selling Partner / Business APIs are
+for sellers and business accounts. So a personal "button that orders" has to
+borrow your own logged-in session.
+
+This project does that the simplest way that works:
+
+1. You paste your **logged-in Amazon session cookies** into `secrets.h` once.
+2. Tapping a tile makes an HTTPS request to Amazon's **add-to-cart endpoint**
+   (`/gp/aws/cart/add.html`), replaying those cookies, so the item lands in
+   **your** cart.
+3. The screen shows ✓ / ✗ and beeps. You finish checkout from the Amazon app.
+
+It deliberately stops at *add to cart*, not *place order* — adding to cart is
+reliable; full headless checkout (addresses, payment, OTP/captcha) is not, and
+one misfire there buys you the wrong thing.
+
+> [!WARNING]
+> Please read before building:
+> - **Your Amazon login lives on the device.** The session cookies are
+>   effectively your account. Don't put this on a device you don't physically
+>   control, and don't share a flash dump.
+> - **It's a gray area under Amazon's Terms of Service** and it's inherently
+>   fragile. Amazon rotates session tokens and runs anti-bot checks; expect to
+>   re-paste cookies every so often when tiles start saying *Sign-in needed*.
+>   No guarantees it keeps working — treat it as a fun hack, not a product.
+> - **No affiliate tag in this mode.** Amazon Associates forbids earning fees on
+>   your own purchases, so adding to your own cart must run untagged
+>   (`AFFILIATE_TAG ""`). The tag plumbing only exists for a separate
+>   share-with-others build that hands the link off via QR instead.
+
+## Hardware
+
+- [Elecrow ESP32-S3 3.5" Terminal](https://www.elecrow.com/esp-terminal-3-5-inch-320-480-spi-tft-capacitive-touch-display-with-ov2640-camera.html)
+  — 480×320, ILI9488, FT6236 capacitive touch, LVGL-certified, Wi-Fi + buzzer.
+  Any ESP32-S3 + LVGL touchscreen works; you'll just adjust the pins.
+- A USB-C cable and a Wi-Fi network.
+
+## Build
+
+Uses [PlatformIO](https://platformio.org/).
+
+1. Copy the secrets template and fill it in:
+   ```bash
+   cp src/secrets.example.h src/secrets.h
+   ```
+   Set `WIFI_SSID` / `WIFI_PASSWORD`, then paste your Amazon cookies (next
+   section).
+2. Edit `src/products.h` — replace the placeholder `B000000000` ASINs with the
+   real products you reorder. Make sure `AMAZON_HOST` in `src/config.h` matches
+   your storefront (`www.amazon.com`, `www.amazon.co.uk`, …).
+3. Flash it:
+   ```bash
+   pio run -t upload && pio device monitor
+   ```
+
+### Getting your Amazon cookies
+
+On a desktop browser logged into the **same** Amazon account/storefront:
+
+1. Log in with **"Keep me signed in"** checked.
+2. Open **DevTools → Network**, reload the Amazon home page.
+3. Click the top document request → **Headers → Request Headers**.
+4. Copy the entire value of the **`cookie:`** header.
+5. Paste it into `AMAZON_COOKIE` in `src/secrets.h` (escape any `"` as `\"`).
+
+When tiles start reporting **Sign-in needed**, repeat these steps and re-flash.
+
+### Finding an ASIN
+
+It's the 10-character code in any product URL —
+`amazon.com/dp/`**`B0XXXXXXXX`** — or under "Product details" on the listing.
+A single tile can bundle several ASINs (see the `Trash + Liners` example in
+`products.h`) so one tap reorders a kit.
+
+## Customising
+
+| What | Where |
+|------|-------|
+| Items / tiles / quantities | `src/products.h` |
+| Storefront, timeouts, buzzer, grid size | `src/config.h` |
+| Wi-Fi + Amazon cookies (gitignored) | `src/secrets.h` |
+| Display & touch pins | `src/board.h` |
+
+## Project layout
+
+```
+src/
+  main.cpp          LVGL + display/touch wiring, the loop
+  ui.cpp / ui.h     the home grid + "adding…/result" screen
+  amazon_client.*   the authenticated add-to-cart HTTPS request
+  amazon_cart.*     builds the /gp/aws/cart/add.html URL
+  products.h        YOUR catalog (edit me)
+  config.h          non-secret settings
+  secrets.example.h template -> copy to secrets.h
+  board.h           all board-specific pins
+  display.cpp/.h    Arduino_GFX panel bring-up
+  touch.cpp/.h      FT6236 capacitive touch + coordinate mapping
+  lv_conf.h         minimal LVGL config
+```
+
+## Troubleshooting
+
+- **Black screen / garbled colors** — wrong panel pins for your SKU. Copy the
+  `Arduino_GFX` constructor from Elecrow's official LVGL demo for your exact
+  board into `src/display.cpp`, and try toggling `COLOR_SWAP` (board.h) +
+  `LV_COLOR_16_SWAP` (lv_conf.h) together.
+- **Taps land in the wrong place** — set `TOUCH_DEBUG 1` in `touch.cpp`, watch
+  the serial monitor, and adjust `TOUCH_SWAP_XY` / `TOUCH_INVERT_X` /
+  `TOUCH_INVERT_Y` in `board.h`.
+- **Every tap says "Sign-in needed"** — cookies expired or are from a different
+  storefront. Re-grab them and confirm `AMAZON_HOST` matches.
+- **"Failed / HTTP 4xx"** — Amazon changed/blocked the request, or the ASIN is
+  unavailable in your region. This is the fragile part; the QR-handoff approach
+  is the robust fallback if you'd rather not chase it.
+
+---
+
+Part of the [macintosh-mini](../) project. Personal, non-commercial use; not
+affiliated with or endorsed by Amazon.

--- a/pantry-terminal/platformio.ini
+++ b/pantry-terminal/platformio.ini
@@ -1,0 +1,27 @@
+; PlatformIO project for the pantry quick-reorder terminal.
+; Target: Elecrow ESP32-S3 3.5" Terminal (480x320, ILI9488, FT6236 touch).
+;
+;   pio run -t upload && pio device monitor
+;
+; If your exact Elecrow SKU differs, the things to adjust are the pins in
+; src/board.h and (for an SPI panel) the bus constructor in src/display.cpp.
+
+[env:elecrow-esp32s3-terminal]
+platform  = espressif32
+board     = esp32-s3-devkitc-1
+framework = arduino
+
+board_build.flash_size = 16MB
+board_build.partitions = default_16MB.csv
+
+build_flags =
+  -I src
+  -DLV_CONF_INCLUDE_SIMPLE
+  -DBOARD_HAS_PSRAM
+
+lib_deps =
+  lvgl/lvgl @ ^8.3.11
+  moononournation/GFX Library for Arduino @ ^1.4.9
+
+monitor_speed   = 115200
+monitor_filters = esp32_exception_decoder

--- a/pantry-terminal/src/amazon_cart.cpp
+++ b/pantry-terminal/src/amazon_cart.cpp
@@ -1,0 +1,58 @@
+#include "amazon_cart.h"
+#include "config.h"
+
+// Percent-encode anything that isn't an RFC 3986 unreserved character. ASINs
+// and a well-formed tag are already URL-safe, but encoding keeps us honest if
+// someone drops an unusual character into config.
+static String urlEncode(const String& s) {
+  static const char* hex = "0123456789ABCDEF";
+  String out;
+  out.reserve(s.length() * 3);
+  for (size_t i = 0; i < s.length(); i++) {
+    char c = s[i];
+    bool unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                      (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+                      c == '.' || c == '~';
+    if (unreserved) {
+      out += c;
+    } else {
+      out += '%';
+      out += hex[(c >> 4) & 0xF];
+      out += hex[c & 0xF];
+    }
+  }
+  return out;
+}
+
+// Empty for personal/own-account use (the default). See config.h for why a tag
+// must stay empty when adding to your own cart.
+static String affiliateTag() {
+  return String(AFFILIATE_TAG);
+}
+
+String buildCartUrl(const Product& product) {
+  String url = "https://";
+  url += AMAZON_HOST;
+  url += "/gp/aws/cart/add.html";
+
+  char sep = '?';
+  String tag = affiliateTag();
+  if (tag.length() > 0) {
+    url += sep; sep = '&';
+    url += "AssociateTag=";
+    url += urlEncode(tag);
+  }
+
+  uint8_t n = product.count > MAX_ASINS ? MAX_ASINS : product.count;
+  for (uint8_t i = 0; i < n; i++) {
+    const CartItem& item = product.items[i];
+    if (item.asin == nullptr || item.asin[0] == '\0') continue;
+    int idx = i + 1;  // Amazon uses 1-based ASIN.1, Quantity.1, ...
+    url += sep; sep = '&';
+    url += "ASIN."; url += idx; url += '=';
+    url += urlEncode(String(item.asin));
+    url += "&Quantity."; url += idx; url += '=';
+    url += (item.qty == 0 ? 1 : item.qty);
+  }
+  return url;
+}

--- a/pantry-terminal/src/amazon_cart.h
+++ b/pantry-terminal/src/amazon_cart.h
@@ -1,0 +1,10 @@
+// amazon_cart.h — turns a Product into an Amazon "add to cart" URL.
+#pragma once
+#include <Arduino.h>
+#include "products.h"
+
+// Builds a URL of the form:
+//   https://HOST/gp/aws/cart/add.html?AssociateTag=TAG&ASIN.1=..&Quantity.1=..
+// The AssociateTag parameter is omitted entirely when no tag is configured.
+// Scanning/opening the result lands on Amazon with the item(s) in the cart.
+String buildCartUrl(const Product& product);

--- a/pantry-terminal/src/amazon_client.cpp
+++ b/pantry-terminal/src/amazon_client.cpp
@@ -1,0 +1,111 @@
+#include "amazon_client.h"
+#include "amazon_cart.h"
+#include "config.h"
+#include "secrets.h"
+
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+
+// A desktop-ish UA — Amazon's add-to-cart path behaves better than with the
+// default ESP32 UA. This is the same string a normal browser would send.
+static const char* USER_AGENT =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36";
+
+static bool ensureWifi() {
+  if (WiFi.status() == WL_CONNECTED) return true;
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  uint32_t start = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - start < 15000) {
+    delay(200);
+  }
+  return WiFi.status() == WL_CONNECTED;
+}
+
+void amazonClientBegin() {
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+}
+
+// Read up to `max` bytes of the response so we can sniff for a sign-in wall
+// without pulling Amazon's (huge) cart page fully into RAM.
+static String peekBody(HTTPClient& http, size_t max = 6144) {
+  String out;
+  out.reserve(max);
+  WiFiClient* stream = http.getStreamPtr();
+  uint32_t start = millis();
+  while (out.length() < max && (http.connected() || stream->available()) &&
+         millis() - start < HTTP_TIMEOUT_MS) {
+    while (stream->available() && out.length() < max) {
+      out += (char)stream->read();
+    }
+    if (out.length() < max) delay(5);
+  }
+  return out;
+}
+
+// True if the response looks like Amazon bounced us to a login page, meaning
+// the stored cookies have expired or been invalidated.
+static bool looksLikeSignIn(const String& url, const String& body) {
+  if (url.indexOf("/ap/signin") >= 0) return true;
+  if (body.indexOf("ap/signin") >= 0) return true;
+  if (body.indexOf("nav-signin") >= 0) return true;     // signed-out nav
+  if (body.indexOf("Sign in for the best experience") >= 0) return true;
+  return false;
+}
+
+OrderResult addToCart(const Product& product, String* detail) {
+  if (!ensureWifi()) {
+    if (detail) *detail = "No Wi-Fi";
+    return ORDER_NET_ERROR;
+  }
+
+  String url = buildCartUrl(product);
+
+  WiFiClientSecure client;
+  // NOTE: we skip TLS certificate validation for simplicity. On a trusted home
+  // network the practical risk is low, but to harden against MITM, paste the
+  // "Amazon Root CA 1" PEM and call client.setCACert(...) instead.
+  client.setInsecure();
+
+  HTTPClient http;
+  http.setReuse(false);
+  http.setTimeout(HTTP_TIMEOUT_MS);
+  http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
+  if (!http.begin(client, url)) {
+    if (detail) *detail = "Connect failed";
+    return ORDER_NET_ERROR;
+  }
+
+  http.addHeader("Cookie", AMAZON_COOKIE);
+  http.addHeader("User-Agent", USER_AGENT);
+  http.addHeader("Accept", "text/html,application/xhtml+xml");
+  http.addHeader("Accept-Language", "en-US,en;q=0.9");
+
+  int code = http.GET();
+  if (code <= 0) {
+    if (detail) *detail = String("Net err ") + code;
+    http.end();
+    return ORDER_NET_ERROR;
+  }
+
+  String finalUrl = http.getLocation();
+  if (finalUrl.length() == 0) finalUrl = url;
+  String body = peekBody(http);
+  http.end();
+
+  if (looksLikeSignIn(finalUrl, body)) {
+    if (detail) *detail = "Session expired";
+    return ORDER_AUTH_EXPIRED;
+  }
+
+  if (code >= 200 && code < 400) {
+    if (detail) *detail = "Added to cart";
+    return ORDER_OK;
+  }
+
+  if (detail) *detail = String("HTTP ") + code;
+  return ORDER_HTTP_ERROR;
+}

--- a/pantry-terminal/src/amazon_client.h
+++ b/pantry-terminal/src/amazon_client.h
@@ -1,0 +1,19 @@
+// amazon_client.h — performs the authenticated add-to-cart request.
+#pragma once
+#include <Arduino.h>
+#include "products.h"
+
+enum OrderResult {
+  ORDER_OK,           // item(s) added to your cart
+  ORDER_AUTH_EXPIRED, // request hit a sign-in wall -> refresh cookies
+  ORDER_NET_ERROR,    // Wi-Fi/TLS/connection failure
+  ORDER_HTTP_ERROR,   // unexpected HTTP status from Amazon
+};
+
+// Connects to Wi-Fi if needed and adds the product to your Amazon cart by
+// replaying the stored session cookies. Blocking; expected to take a couple of
+// seconds. `detail` (optional) receives a short human-readable status.
+OrderResult addToCart(const Product& product, String* detail = nullptr);
+
+// Kick off Wi-Fi early (called from setup) so the first tap is snappy.
+void amazonClientBegin();

--- a/pantry-terminal/src/board.h
+++ b/pantry-terminal/src/board.h
@@ -1,0 +1,55 @@
+// board.h — ALL board-specific pins live here.
+//
+// =====================  READ THIS BEFORE YOU FLASH  ========================
+// These defaults target the *Elecrow ESP32-S3 3.5" Terminal* (480x320, ILI9488
+// parallel, FT6236 capacitive touch). Elecrow ships several similar SKUs with
+// different pinouts. The single most reliable thing you can do is open
+// Elecrow's own LVGL/Arduino_GFX demo for YOUR exact board and copy the
+// Arduino_GFX constructor + touch I2C pins into this file. If the screen stays
+// black or touch is offset, that's the knob to turn — not the app code.
+// ===========================================================================
+#pragma once
+
+// ---- Display (ILI9488, 8-bit 8080 parallel via Arduino_GFX) ----------------
+#define TFT_BL   46   // backlight enable (active high)
+
+#define TFT_DC   2
+#define TFT_CS   46   // some Elecrow parallel panels tie CS; verify
+#define TFT_WR   1
+#define TFT_RD   41
+
+// D0..D7 data bus
+#define TFT_D0   41
+#define TFT_D1   40
+#define TFT_D2   39
+#define TFT_D3   38
+#define TFT_D4   37
+#define TFT_D5   36
+#define TFT_D6   35
+#define TFT_D7   45
+
+#define TFT_RST  -1   // -1 if tied to the board reset
+
+// Logical (post-rotation) screen size used by the app.
+#define SCREEN_WIDTH  480
+#define SCREEN_HEIGHT 320
+#define SCREEN_ROTATION 1   // 1 or 3 = landscape on a native-portrait ILI9488
+
+// If colors look inverted/wrong, flip this (and LV_COLOR_16_SWAP in lv_conf.h).
+#define COLOR_SWAP 0
+
+// ---- Capacitive touch (FT6236 / FT6336, I2C @ 0x38) ------------------------
+#define TOUCH_SDA  38
+#define TOUCH_SCL  39
+#define TOUCH_RST  -1
+#define TOUCH_INT  -1
+#define TOUCH_I2C_ADDR 0x38
+
+// Touch panel reports coordinates in the panel's native orientation. These
+// knobs map raw touch -> screen pixels for SCREEN_ROTATION above. Tune by
+// printing raw values (see touch.cpp) and adjusting until a tap lands true.
+#define TOUCH_SWAP_XY   1
+#define TOUCH_INVERT_X  0
+#define TOUCH_INVERT_Y  1
+#define TOUCH_RAW_MAX_X 320   // native panel max along its X
+#define TOUCH_RAW_MAX_Y 480   // native panel max along its Y

--- a/pantry-terminal/src/config.h
+++ b/pantry-terminal/src/config.h
@@ -1,0 +1,35 @@
+// config.h — non-secret settings you'll tweak. Secrets (Wi-Fi password, Amazon
+// session cookies) live in secrets.h, which is gitignored. Copy
+// secrets.example.h -> secrets.h and fill it in.
+//
+// How it works: tapping a tile makes an HTTPS request to Amazon's add-to-cart
+// endpoint, replaying YOUR logged-in session cookies, so the item lands in your
+// real cart. You then open the Amazon app and tap Buy. No QR, no backend.
+#pragma once
+
+// ---------------------------------------------------------------------------
+// Amazon storefront — must match the account your cookies belong to.
+//   US "www.amazon.com"  UK "www.amazon.co.uk"  DE "www.amazon.de"
+//   CA "www.amazon.ca"   JP "www.amazon.co.jp"  ...
+// ---------------------------------------------------------------------------
+#define AMAZON_HOST "www.amazon.com"
+
+// ---------------------------------------------------------------------------
+// Affiliate tag — KEEP EMPTY for this (personal, own-cart) mode.
+// Amazon Associates forbids earning fees on your own purchases, so a direct-
+// to-your-own-cart build must not carry a tag. The tag plumbing only exists
+// for a separate share-with-others QR build. Leave "" here.
+// ---------------------------------------------------------------------------
+#define AFFILIATE_TAG ""
+
+// ---------------------------------------------------------------------------
+// Behaviour
+// ---------------------------------------------------------------------------
+#define HTTP_TIMEOUT_MS    12000  // per add-to-cart request
+#define CONFIRM_TIMEOUT_MS 20000  // auto-return to the grid after showing a result
+#define BUZZER_ENABLED     true   // short beep on tap (Elecrow Terminal has a buzzer)
+#define BUZZER_PIN         3      // verify against your board's pinout
+
+// UI grid layout on the 480x320 screen.
+#define GRID_COLS 3
+#define GRID_ROWS 2

--- a/pantry-terminal/src/display.cpp
+++ b/pantry-terminal/src/display.cpp
@@ -1,0 +1,23 @@
+#include "display.h"
+#include "board.h"
+
+// 8-bit 8080 parallel bus -> ILI9488. If your Elecrow SKU is the SPI variant,
+// replace this with the Arduino_ESP32SPI bus from Elecrow's demo instead.
+static Arduino_DataBus* bus = new Arduino_ESP32LCD8(
+    TFT_DC, TFT_CS, TFT_WR, TFT_RD,
+    TFT_D0, TFT_D1, TFT_D2, TFT_D3,
+    TFT_D4, TFT_D5, TFT_D6, TFT_D7);
+
+// 18-bit color init is what these ILI9488 panels expect over parallel.
+Arduino_GFX* gfx =
+    new Arduino_ILI9488_18bit(bus, TFT_RST, SCREEN_ROTATION, false /* IPS */);
+
+void displayBegin() {
+  gfx->begin();
+  gfx->fillScreen(BLACK);
+
+#ifdef TFT_BL
+  pinMode(TFT_BL, OUTPUT);
+  digitalWrite(TFT_BL, HIGH);  // backlight on
+#endif
+}

--- a/pantry-terminal/src/display.h
+++ b/pantry-terminal/src/display.h
@@ -1,0 +1,8 @@
+// display.h — display bring-up (Arduino_GFX) exposed to main.cpp.
+#pragma once
+#include <Arduino_GFX_Library.h>
+
+extern Arduino_GFX* gfx;
+
+// Initialise the panel + backlight. Call once from setup().
+void displayBegin();

--- a/pantry-terminal/src/lv_conf.h
+++ b/pantry-terminal/src/lv_conf.h
@@ -1,0 +1,26 @@
+// lv_conf.h — minimal LVGL 8.x configuration for the pantry terminal.
+// Resolved via -DLV_CONF_INCLUDE_SIMPLE and -I src (see platformio.ini).
+// Anything not set here falls back to LVGL's built-in defaults.
+#pragma once
+
+#define LV_COLOR_DEPTH 16
+
+// Set to 1 if reds/blues look swapped (and flip COLOR_SWAP in board.h to match
+// the byte order Arduino_GFX writes).
+#define LV_COLOR_16_SWAP 0
+
+// Drive LVGL's tick from Arduino's millis() so we don't need a hardware timer.
+#define LV_TICK_CUSTOM 1
+#define LV_TICK_CUSTOM_INCLUDE "Arduino.h"
+#define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())
+
+// Heap for LVGL objects/styles.
+#define LV_MEM_SIZE (48U * 1024U)
+
+// Fonts used by ui.cpp.
+#define LV_FONT_MONTSERRAT_16 1
+#define LV_FONT_MONTSERRAT_20 1
+#define LV_FONT_MONTSERRAT_28 1
+#define LV_FONT_DEFAULT &lv_font_montserrat_16
+
+// Widgets used: button, label, spinner (arc) — all on by default in 8.x.

--- a/pantry-terminal/src/main.cpp
+++ b/pantry-terminal/src/main.cpp
@@ -1,0 +1,69 @@
+#include <Arduino.h>
+#include <lvgl.h>
+
+#include "board.h"
+#include "display.h"
+#include "touch.h"
+#include "ui.h"
+#include "amazon_client.h"
+
+// LVGL draw buffer — a few dozen lines tall is plenty and fits internal RAM.
+#define DRAW_BUF_LINES 48
+static lv_disp_draw_buf_t draw_buf;
+static lv_color_t* buf1;
+
+static void disp_flush(lv_disp_drv_t* drv, const lv_area_t* area,
+                       lv_color_t* color_p) {
+  uint32_t w = area->x2 - area->x1 + 1;
+  uint32_t h = area->y2 - area->y1 + 1;
+  gfx->draw16bitRGBBitmap(area->x1, area->y1, (uint16_t*)color_p, w, h);
+  lv_disp_flush_ready(drv);
+}
+
+static void touch_read(lv_indev_drv_t* drv, lv_indev_data_t* data) {
+  int16_t x, y;
+  if (touchRead(&x, &y)) {
+    data->state = LV_INDEV_STATE_PRESSED;
+    data->point.x = x;
+    data->point.y = y;
+  } else {
+    data->state = LV_INDEV_STATE_RELEASED;
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+
+  displayBegin();
+  touchBegin();
+  lv_init();
+
+  size_t buf_px = SCREEN_WIDTH * DRAW_BUF_LINES;
+  buf1 = (lv_color_t*)heap_caps_malloc(buf_px * sizeof(lv_color_t),
+                                       MALLOC_CAP_DMA);
+  if (!buf1) buf1 = (lv_color_t*)malloc(buf_px * sizeof(lv_color_t));
+  lv_disp_draw_buf_init(&draw_buf, buf1, NULL, buf_px);
+
+  static lv_disp_drv_t disp_drv;
+  lv_disp_drv_init(&disp_drv);
+  disp_drv.hor_res = SCREEN_WIDTH;
+  disp_drv.ver_res = SCREEN_HEIGHT;
+  disp_drv.flush_cb = disp_flush;
+  disp_drv.draw_buf = &draw_buf;
+  lv_disp_drv_register(&disp_drv);
+
+  static lv_indev_drv_t indev_drv;
+  lv_indev_drv_init(&indev_drv);
+  indev_drv.type = LV_INDEV_TYPE_POINTER;
+  indev_drv.read_cb = touch_read;
+  lv_indev_drv_register(&indev_drv);
+
+  uiInit();
+  amazonClientBegin();  // start associating to Wi-Fi so the first tap is quick
+}
+
+void loop() {
+  lv_timer_handler();
+  uiLoop();
+  delay(5);
+}

--- a/pantry-terminal/src/products.h
+++ b/pantry-terminal/src/products.h
@@ -1,0 +1,41 @@
+// products.h — your pantry catalog. This is the other file you'll edit a lot.
+//
+// Each tile is one Product. Find a product's ASIN on its Amazon page (it's the
+// 10-character code in the URL, e.g. amazon.com/dp/B0BXXXXXXX -> "B0BXXXXXXX",
+// or under "Product details"). A Product can bundle up to MAX_ASINS items so a
+// single tap can reorder a whole kit (e.g. detergent + dryer sheets).
+//
+// `symbol` is shown big on the tile. You can use any LVGL built-in symbol
+// (LV_SYMBOL_*) or just a short text label — see ui.cpp for how it's drawn.
+#pragma once
+#include <stdint.h>
+
+#define MAX_ASINS 3
+
+struct CartItem {
+  const char* asin;   // 10-char Amazon ASIN
+  uint8_t     qty;    // how many to add
+};
+
+struct Product {
+  const char* name;             // shown under the tile
+  const char* symbol;           // big glyph/short text on the tile
+  CartItem    items[MAX_ASINS]; // one or more ASINs added together
+  uint8_t     count;            // how many entries in items[] are used
+};
+
+// ---------------------------------------------------------------------------
+// EDIT ME: replace the placeholder ASINs (B000000000) with the real products
+// you want to reorder. Keep `count` in sync with how many items you list.
+// ---------------------------------------------------------------------------
+static const Product PRODUCTS[] = {
+  { "Toilet Paper",   "TP",  { {"B000000000", 1} }, 1 },
+  { "Paper Towels",   "PT",  { {"B000000000", 1} }, 1 },
+  { "Hand Soap",      "SOAP",{ {"B000000000", 2} }, 1 },
+  { "Laundry Det.",   "LDY", { {"B000000000", 1} }, 1 },
+  { "Dish Soap",      "DISH",{ {"B000000000", 1} }, 1 },
+  // Example of a one-tap bundle (two ASINs ordered together):
+  { "Trash + Liners", "BAG", { {"B000000000", 1}, {"B000000001", 1} }, 2 },
+};
+
+static const uint8_t PRODUCT_COUNT = sizeof(PRODUCTS) / sizeof(PRODUCTS[0]);

--- a/pantry-terminal/src/secrets.example.h
+++ b/pantry-terminal/src/secrets.example.h
@@ -1,0 +1,31 @@
+// secrets.example.h — copy this to secrets.h (which is gitignored) and fill in.
+//
+//   cp src/secrets.example.h src/secrets.h
+//
+// secrets.h holds your Wi-Fi password and — importantly — your logged-in
+// Amazon session cookies. Those cookies are effectively your Amazon login.
+// Treat this file like a password: never commit it, never share a device dump.
+#pragma once
+
+// ---- Wi-Fi (required: direct add-to-cart needs the network) ----------------
+#define WIFI_SSID     "your-ssid"
+#define WIFI_PASSWORD "your-password"
+
+// ---- Amazon session cookies ------------------------------------------------
+// Paste the FULL cookie header from a browser that's logged into the same
+// amazon.com account and storefront as AMAZON_HOST in config.h.
+//
+// How to grab it (desktop Chrome/Firefox):
+//   1. Log into amazon.com with "Keep me signed in" checked.
+//   2. Open DevTools -> Network tab, reload the Amazon home page.
+//   3. Click the top document request -> Headers -> Request Headers.
+//   4. Copy the entire value of the "cookie:" header.
+//   5. Paste it below as one line. Escape any double-quotes as \".
+//
+// The important ones are session-id, ubid-main, x-main, at-main, sess-at-main,
+// session-token. It's simplest to just paste everything verbatim.
+//
+// These rotate over time. When tiles start reporting "Session expired", repeat
+// the steps above and re-flash (or update it via the device's config portal if
+// you wire one up).
+#define AMAZON_COOKIE "session-id=000-0000000-0000000; ubid-main=000-0000000-0000000; x-main=...; at-main=...; sess-at-main=\"...\"; session-token=..."

--- a/pantry-terminal/src/touch.cpp
+++ b/pantry-terminal/src/touch.cpp
@@ -1,0 +1,63 @@
+#include "touch.h"
+#include "board.h"
+#include <Wire.h>
+
+// Set to 1 to print raw touch coordinates to Serial while calibrating the
+// TOUCH_* knobs in board.h.
+#define TOUCH_DEBUG 0
+
+void touchBegin() {
+  Wire.begin(TOUCH_SDA, TOUCH_SCL);
+  Wire.setClock(400000);
+#if TOUCH_RST >= 0
+  pinMode(TOUCH_RST, OUTPUT);
+  digitalWrite(TOUCH_RST, LOW);
+  delay(10);
+  digitalWrite(TOUCH_RST, HIGH);
+  delay(50);
+#endif
+}
+
+// Read FT6x36 registers 0x02 (touch count) and 0x03..0x06 (X/Y hi+lo of point 1).
+static bool readRaw(uint16_t* rx, uint16_t* ry) {
+  Wire.beginTransmission(TOUCH_I2C_ADDR);
+  Wire.write(0x02);
+  if (Wire.endTransmission(false) != 0) return false;
+  if (Wire.requestFrom(TOUCH_I2C_ADDR, 5) != 5) return false;
+
+  uint8_t touches = Wire.read() & 0x0F;
+  uint8_t xh = Wire.read();
+  uint8_t xl = Wire.read();
+  uint8_t yh = Wire.read();
+  uint8_t yl = Wire.read();
+  if (touches == 0 || touches > 2) return false;
+
+  *rx = ((xh & 0x0F) << 8) | xl;
+  *ry = ((yh & 0x0F) << 8) | yl;
+  return true;
+}
+
+bool touchRead(int16_t* x, int16_t* y) {
+  uint16_t rx, ry;
+  if (!readRaw(&rx, &ry)) return false;
+
+#if TOUCH_DEBUG
+  Serial.printf("raw touch  x=%u  y=%u\n", rx, ry);
+#endif
+
+  // Map raw panel coordinates -> screen pixels per the knobs in board.h.
+  long sx, sy;
+  if (TOUCH_SWAP_XY) {
+    sx = (long)ry * SCREEN_WIDTH / TOUCH_RAW_MAX_Y;
+    sy = (long)rx * SCREEN_HEIGHT / TOUCH_RAW_MAX_X;
+  } else {
+    sx = (long)rx * SCREEN_WIDTH / TOUCH_RAW_MAX_X;
+    sy = (long)ry * SCREEN_HEIGHT / TOUCH_RAW_MAX_Y;
+  }
+  if (TOUCH_INVERT_X) sx = SCREEN_WIDTH - 1 - sx;
+  if (TOUCH_INVERT_Y) sy = SCREEN_HEIGHT - 1 - sy;
+
+  *x = constrain(sx, 0, SCREEN_WIDTH - 1);
+  *y = constrain(sy, 0, SCREEN_HEIGHT - 1);
+  return true;
+}

--- a/pantry-terminal/src/touch.h
+++ b/pantry-terminal/src/touch.h
@@ -1,0 +1,8 @@
+// touch.h — capacitive touch read, mapped to screen pixels.
+#pragma once
+#include <Arduino.h>
+
+void touchBegin();
+
+// Returns true if a finger is down; writes screen-space coordinates to x,y.
+bool touchRead(int16_t* x, int16_t* y);

--- a/pantry-terminal/src/ui.cpp
+++ b/pantry-terminal/src/ui.cpp
@@ -1,0 +1,183 @@
+#include "ui.h"
+#include <lvgl.h>
+#include <Arduino.h>
+
+#include "config.h"
+#include "products.h"
+#include "amazon_client.h"
+
+// ---- screens / widgets -----------------------------------------------------
+static lv_obj_t* scr_home;
+static lv_obj_t* scr_status;
+static lv_obj_t* status_title;
+static lv_obj_t* status_msg;
+static lv_obj_t* status_spinner;
+
+// ---- deferred-work state ---------------------------------------------------
+static int      pending_order = -1;   // product index queued by a tap
+static bool     showing_result = false;
+static uint32_t result_at = 0;
+
+static void beep(bool ok) {
+#if BUZZER_ENABLED
+  tone(BUZZER_PIN, ok ? 1700 : 320, ok ? 70 : 200);
+#endif
+}
+
+static void showHome() {
+  showing_result = false;
+  lv_scr_load(scr_home);
+}
+
+static void showBusy(const char* name) {
+  lv_label_set_text(status_title, "Adding to cart");
+  lv_label_set_text(status_msg, name);
+  lv_obj_set_style_text_color(status_title, lv_color_white(), 0);
+  lv_obj_clear_flag(status_spinner, LV_OBJ_FLAG_HIDDEN);
+  lv_scr_load(scr_status);
+  lv_refr_now(NULL);  // force the busy screen to paint before we block on Wi-Fi
+}
+
+static void showResult(OrderResult r, const char* name, const String& detail) {
+  lv_obj_add_flag(status_spinner, LV_OBJ_FLAG_HIDDEN);
+
+  lv_color_t color;
+  const char* title;
+  switch (r) {
+    case ORDER_OK:
+      title = LV_SYMBOL_OK "  Added";
+      color = lv_palette_main(LV_PALETTE_GREEN);
+      break;
+    case ORDER_AUTH_EXPIRED:
+      title = LV_SYMBOL_WARNING "  Sign-in needed";
+      color = lv_palette_main(LV_PALETTE_AMBER);
+      break;
+    default:
+      title = LV_SYMBOL_CLOSE "  Failed";
+      color = lv_palette_main(LV_PALETTE_RED);
+      break;
+  }
+  lv_label_set_text(status_title, title);
+  lv_obj_set_style_text_color(status_title, color, 0);
+
+  String msg = String(name);
+  if (r == ORDER_OK) {
+    msg += "\nOpen the Amazon app to check out.";
+  } else if (r == ORDER_AUTH_EXPIRED) {
+    msg += "\nRefresh the Amazon cookies in secrets.h.";
+  } else {
+    msg += "\n" + detail;
+  }
+  lv_label_set_text(status_msg, msg.c_str());
+
+  beep(r == ORDER_OK);
+  showing_result = true;
+  result_at = millis();
+}
+
+// ---- events ----------------------------------------------------------------
+static void tile_clicked(lv_event_t* e) {
+  lv_obj_t* btn = lv_event_get_target(e);
+  int idx = (int)(intptr_t)lv_obj_get_user_data(btn);
+  if (idx < 0 || idx >= PRODUCT_COUNT) return;
+  showBusy(PRODUCTS[idx].name);
+  pending_order = idx;  // actual request runs in uiLoop()
+}
+
+static void back_clicked(lv_event_t* e) { showHome(); }
+
+// ---- builders --------------------------------------------------------------
+static lv_obj_t* makeTile(lv_obj_t* parent, const Product& p, int idx) {
+  lv_obj_t* btn = lv_btn_create(parent);
+  lv_obj_set_size(btn, 148, 118);
+  lv_obj_set_style_radius(btn, 14, 0);
+  lv_obj_set_user_data(btn, (void*)(intptr_t)idx);
+  lv_obj_add_event_cb(btn, tile_clicked, LV_EVENT_CLICKED, NULL);
+
+  lv_obj_t* sym = lv_label_create(btn);
+  lv_label_set_text(sym, p.symbol);
+  lv_obj_set_style_text_font(sym, &lv_font_montserrat_28, 0);
+  lv_obj_align(sym, LV_ALIGN_TOP_MID, 0, 6);
+
+  lv_obj_t* name = lv_label_create(btn);
+  lv_label_set_text(name, p.name);
+  lv_label_set_long_mode(name, LV_LABEL_LONG_WRAP);
+  lv_obj_set_width(name, 134);
+  lv_obj_set_style_text_align(name, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_text_font(name, &lv_font_montserrat_16, 0);
+  lv_obj_align(name, LV_ALIGN_BOTTOM_MID, 0, -6);
+  return btn;
+}
+
+static void buildHome() {
+  scr_home = lv_obj_create(NULL);
+  lv_obj_set_style_bg_color(scr_home, lv_color_hex(0x101418), 0);
+
+  lv_obj_t* header = lv_label_create(scr_home);
+  lv_label_set_text(header, "Pantry Reorder");
+  lv_obj_set_style_text_color(header, lv_color_white(), 0);
+  lv_obj_set_style_text_font(header, &lv_font_montserrat_20, 0);
+  lv_obj_align(header, LV_ALIGN_TOP_MID, 0, 6);
+
+  lv_obj_t* grid = lv_obj_create(scr_home);
+  lv_obj_set_size(grid, SCREEN_WIDTH, SCREEN_HEIGHT - 36);
+  lv_obj_align(grid, LV_ALIGN_BOTTOM_MID, 0, 0);
+  lv_obj_set_style_bg_opa(grid, LV_OPA_TRANSP, 0);
+  lv_obj_set_style_border_width(grid, 0, 0);
+  lv_obj_set_flex_flow(grid, LV_FLEX_FLOW_ROW_WRAP);
+  lv_obj_set_flex_align(grid, LV_FLEX_ALIGN_SPACE_EVENLY,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+  for (int i = 0; i < PRODUCT_COUNT; i++) makeTile(grid, PRODUCTS[i], i);
+}
+
+static void buildStatus() {
+  scr_status = lv_obj_create(NULL);
+  lv_obj_set_style_bg_color(scr_status, lv_color_hex(0x101418), 0);
+
+  status_spinner = lv_spinner_create(scr_status, 1000, 60);
+  lv_obj_set_size(status_spinner, 64, 64);
+  lv_obj_align(status_spinner, LV_ALIGN_TOP_MID, 0, 30);
+
+  status_title = lv_label_create(scr_status);
+  lv_obj_set_style_text_font(status_title, &lv_font_montserrat_28, 0);
+  lv_obj_set_style_text_color(status_title, lv_color_white(), 0);
+  lv_obj_align(status_title, LV_ALIGN_CENTER, 0, -10);
+
+  status_msg = lv_label_create(scr_status);
+  lv_label_set_long_mode(status_msg, LV_LABEL_LONG_WRAP);
+  lv_obj_set_width(status_msg, SCREEN_WIDTH - 60);
+  lv_obj_set_style_text_align(status_msg, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_text_font(status_msg, &lv_font_montserrat_16, 0);
+  lv_obj_set_style_text_color(status_msg, lv_color_hex(0xC0C7CE), 0);
+  lv_obj_align(status_msg, LV_ALIGN_CENTER, 0, 40);
+
+  lv_obj_t* back = lv_btn_create(scr_status);
+  lv_obj_set_size(back, 140, 48);
+  lv_obj_align(back, LV_ALIGN_BOTTOM_MID, 0, -12);
+  lv_obj_add_event_cb(back, back_clicked, LV_EVENT_CLICKED, NULL);
+  lv_obj_t* bl = lv_label_create(back);
+  lv_label_set_text(bl, LV_SYMBOL_LEFT "  Back");
+  lv_obj_center(bl);
+}
+
+// ---- public ----------------------------------------------------------------
+void uiInit() {
+  buildHome();
+  buildStatus();
+  showHome();
+}
+
+void uiLoop() {
+  if (pending_order >= 0) {
+    int idx = pending_order;
+    pending_order = -1;
+    String detail;
+    OrderResult r = addToCart(PRODUCTS[idx], &detail);
+    showResult(r, PRODUCTS[idx].name, detail);
+    return;
+  }
+  if (showing_result && millis() - result_at > CONFIRM_TIMEOUT_MS) {
+    showHome();
+  }
+}

--- a/pantry-terminal/src/ui.h
+++ b/pantry-terminal/src/ui.h
@@ -1,0 +1,10 @@
+// ui.h — LVGL screens for the pantry terminal.
+#pragma once
+
+// Build the home grid + status screen. Call once after lv_init() and the
+// display/touch drivers are registered.
+void uiInit();
+
+// Call every iteration of loop() (after lv_timer_handler). Runs any pending
+// add-to-cart request and handles the auto-return-to-grid timeout.
+void uiLoop();


### PR DESCRIPTION
## What

A new `pantry-terminal/` sub-project: a small touchscreen for your pantry where tapping a product tile (TP, paper towels, soap, laundry detergent…) drops the item **directly into your real Amazon cart**. You then open the Amazon app and tap Buy. Runs entirely on an **ESP32-S3 + LVGL touchscreen** — no Raspberry Pi, no server, no cloud middleman.

Default hardware target is the **Elecrow ESP32-S3 3.5″ Terminal** (480×320, ILI9488, FT6236 touch), but any ESP32-S3 + LVGL display works by adjusting `board.h`.

## How it works (and the caveats)

There is **no official API for placing orders on a personal Amazon account** (Dash Replenishment is gated to appliance makers; PA-API only builds links; SP-API/Business are for sellers). So the device authenticates *as you*:

1. You paste your logged-in Amazon **session cookies** into `secrets.h` (gitignored).
2. A tap makes an HTTPS request to `/gp/aws/cart/add.html` replaying those cookies → item lands in your cart.
3. The screen shows ✓/✗ + beeps; you finish checkout from the Amazon app.

It deliberately stops at *add-to-cart* (reliable) rather than full headless checkout (fragile: addresses, payment, OTP/captcha).

⚠️ Documented prominently in the README:
- **Your Amazon login lives on the device** — those cookies are effectively your account.
- **Gray area under Amazon's ToS and inherently fragile** — tokens rotate; expect to re-paste cookies periodically.
- **No affiliate tag in this mode** — Associates forbids fees on your own purchases; tagging is reserved for a separate share-with-others (QR-handoff) build.

## Contents

- `main.cpp` + `display.*` / `touch.*` — LVGL wiring, Arduino_GFX panel bring-up, FT6236 touch with coordinate-mapping knobs
- `ui.cpp` — home grid + busy/result screen (network call deferred to the loop so the "Adding…" screen paints before blocking)
- `amazon_client.*` — the authenticated add-to-cart request, with sign-in-wall detection → "Session expired"
- `amazon_cart.*` — builds the cart URL (URL-encoded, multi-ASIN bundles)
- `products.h` / `config.h` / `secrets.example.h` / `board.h` — the edit-me surfaces
- `platformio.ini`, `lv_conf.h`, `.gitignore`

## Status / testing

Drafted because it's **not been flash-tested on hardware** (none available in this environment). The app logic is board-independent; the one thing to verify on a real unit is the display/touch pinout in `board.h` against Elecrow's LVGL demo for the exact SKU. Caveats and troubleshooting are in `pantry-terminal/README.md`.

https://claude.ai/code/session_01DrM3AN8SPZJmJ2WYuH8r9p

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrM3AN8SPZJmJ2WYuH8r9p)_