### PR TITLE
Fix installer crash when a graphics group is missing (W-527)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -781,13 +781,15 @@ fi
 if [[ $INSTALL_SHEEPSHAVER -eq 1 ]]; then
   enable_seatd() {
     sudo systemctl enable --now seatd || return $?
-    local seat_group="" g
-    for g in seat _seatd; do
-      if getent group "$g" >/dev/null 2>&1; then seat_group=$g; break; fi
+    # Only add groups that actually exist — usermod aborts if any listed
+    # group is missing, and distros vary on which of these they ship.
+    local groups="" g
+    for g in seat _seatd video input render; do
+      getent group "$g" >/dev/null 2>&1 && groups="${groups:+$groups,}$g"
     done
-    local groups="video,input,render"
-    [[ -n $seat_group ]] && groups="$seat_group,$groups"
-    sudo usermod -aG "$groups" "$USER"
+    if [[ -n $groups ]]; then
+      sudo usermod -aG "$groups" "$USER"
+    fi
   }
   run "[sheepshaver] Enabling seatd; adding $USER to graphics groups" enable_seatd
 
@@ -950,13 +952,15 @@ fi
 if [[ $INSTALL_BASILISK -eq 1 ]]; then
   enable_seatd_basilisk() {
     sudo systemctl enable --now seatd || return $?
-    local seat_group="" g
-    for g in seat _seatd; do
-      if getent group "$g" >/dev/null 2>&1; then seat_group=$g; break; fi
+    # Only add groups that actually exist — usermod aborts if any listed
+    # group is missing, and distros vary on which of these they ship.
+    local groups="" g
+    for g in seat _seatd video input render; do
+      getent group "$g" >/dev/null 2>&1 && groups="${groups:+$groups,}$g"
     done
-    local groups="video,input,render"
-    [[ -n $seat_group ]] && groups="$seat_group,$groups"
-    sudo usermod -aG "$groups" "$USER"
+    if [[ -n $groups ]]; then
+      sudo usermod -aG "$groups" "$USER"
+    fi
   }
   run "[basilisk] Enabling seatd; adding $USER to graphics groups" enable_seatd_basilisk
 


### PR DESCRIPTION
## Problem

`enable_seatd` / `enable_seatd_basilisk` ran `sudo usermod -aG "video,input,render,..." "$USER"`. `usermod` aborts with a non-zero exit if **any** group in the list doesn't exist, and the `run()` wrapper turns any non-zero return into a full `exit` (the script runs under `set -euo pipefail`). So on any image lacking the `video`/`input`/`render`/`_seatd` groups, the installer crashed at the seatd step.

The old code guarded only the *seat* group (`seat`/`_seatd`) with `getent` while passing `video,input,render` unconditionally — protecting the one group that's actually optional and leaving the three that could crash it unchecked.

Fixes W-527 / #16.

## Fix

Both functions now filter **every** candidate group (`seat _seatd video input render`) through `getent group` and pass `usermod` only the ones that exist. If none exist, `usermod` is skipped entirely (the `if [[ -n $groups ]]` guard also ensures the function returns `0` in that case, so it can't trip `run()`'s `exit`).

Only the seat group is actually load-bearing for this setup (cage/libseat with `LIBSEAT_BACKEND=seatd` — seatd opens the DRM/input devices and passes FDs, so direct `video`/`input`/`render` membership is redundant belt-and-suspenders). Skipping a group that doesn't exist can't remove access the user never had.

## Testing

Verified end-to-end in a QEMU arm64 systemd VM (Debian 12 genericcloud, standing in for Raspberry Pi OS — the logic is distro-generic bash):

- **Fresh image with `render` missing** (`_seatd`/`seat` never exist on stock Debian; deleted `render` to reproduce the bug condition): fixed code exits `0`, user added to only the existing groups (`video input`).
- **All five candidate groups absent:** still exits `0`, skips `usermod` entirely.
- **Regression check:** the pre-fix code on the same image fails with `usermod: group 'render' does not exist` and `run()` exits `6` — i.e. the installer would abort, exactly as reported.