### PR TITLE
Keep the wi-fi radio awake so the Pi stays reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The Pi boots straight into the Mac. A few controls:
 - **Shut Down** from inside Mac OS (Special → Shut Down) quits to the Pi prompt; **Restart** reboots the Mac in place; a crash auto-reboots.
 - **`macintosh`** — run this from the prompt to boot the Mac again.
 - **Networking** works out of the box (slirp NAT). In the Mac, set TCP/IP to **DHCP**.
-- **Wi-fi stays awake.** The Pi's radio sleeps when idle by default, which makes it drop off the network and answer slowly when you come back to it. The installer turns that off. Pass `--wifi-powersave` if you would rather keep the radio's own power saving.
+- **Wi-fi stays awake.** The Pi's radio sleeps when idle by default, which makes it drop off the network and answer slowly when you come back to it. The installer turns that off. Pass `--wifi-powersave` to skip that step on a fresh install — it does not undo an install that already turned power saving off.
 
 Re-run the installer any time to **update** an existing install — it keeps your disk image and settings. To **switch emulator**, pick the other one (Basilisk II ⇄ SheepShaver); each core's prefs are preserved.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The Pi boots straight into the Mac. A few controls:
 - **Shut Down** from inside Mac OS (Special → Shut Down) quits to the Pi prompt; **Restart** reboots the Mac in place; a crash auto-reboots.
 - **`macintosh`** — run this from the prompt to boot the Mac again.
 - **Networking** works out of the box (slirp NAT). In the Mac, set TCP/IP to **DHCP**.
+- **Wi-fi stays awake.** The Pi's radio sleeps when idle by default, which makes it drop off the network and answer slowly when you come back to it. The installer turns that off. Pass `--wifi-powersave` if you would rather keep the radio's own power saving.
 
 Re-run the installer any time to **update** an existing install — it keeps your disk image and settings. To **switch emulator**, pick the other one (Basilisk II ⇄ SheepShaver); each core's prefs are preserved.
 

--- a/maclock-build/README.md
+++ b/maclock-build/README.md
@@ -168,7 +168,65 @@ sudo systemctl enable --now brightness-control button-handler
 
 ---
 
-### 4. Install the emulator
+### 4. Keep the wi-fi awake
+
+The Pi Zero 2 W ships with wi-fi power saving on. The radio parks itself when
+nothing is talking to it, so the Pi falls off the network while idle and is slow
+to answer when you come back — ssh hangs for a while before it wakes up.
+
+Turn it off in three places, so it holds whether NetworkManager is driving the
+link or not:
+
+```bash
+# 1. NetworkManager's default for new connections
+printf '[connection]\nwifi.powersave = 2\n' \
+  | sudo tee /etc/NetworkManager/conf.d/99-wifi-powersave-off.conf
+
+# 2. the wi-fi profile you are already on
+sudo nmcli connection modify "<your-ssid>" 802-11-wireless.powersave 2
+
+# 3. a boot-time unit, for anything NetworkManager does not manage
+sudo tee /etc/systemd/system/wifi-powersave-off.service <<'UNIT'
+[Unit]
+Description=Disable Wi-Fi power saving
+Wants=sys-subsystem-net-devices-wlan0.device
+After=sys-subsystem-net-devices-wlan0.device NetworkManager.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=-/usr/sbin/iw dev wlan0 set power_save off
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now wifi-powersave-off
+```
+
+Apply it to the running radio too, so you do not have to reboot:
+
+```bash
+sudo iw dev wlan0 set power_save off
+```
+
+Check it took:
+
+```bash
+iw dev wlan0 get power_save
+```
+
+You want `Power save: off`. Note `iw` lives in `/usr/sbin`, which is not on a
+normal user's `PATH` over ssh — use the full path or `sudo` if the command is
+not found.
+
+Do **not** restart NetworkManager to apply this. It drops the wi-fi, which cuts
+the ssh session you are running these commands over.
+
+---
+
+### 5. Install the emulator
 
 The hardware side of the maclock is now done. The [setup script](../setup.sh) installs **Basilisk II**; manual build steps are in the [Basilisk II guide](../emulators/BasiliskII.md) (or the [SheepShaver guide](../emulators/SheepShaver.md) for PowerPC).
 

--- a/setup.sh
+++ b/setup.sh
@@ -663,11 +663,14 @@ if [[ $WIFI_POWERSAVE -eq 0 ]]; then
     printf '[connection]\nwifi.powersave = 2\n' \
       | sudo tee /etc/NetworkManager/conf.d/99-wifi-powersave-off.conf >/dev/null
 
-    local c
-    while IFS= read -r c; do
-      [[ -n $c ]] || continue
-      sudo nmcli connection modify "$c" 802-11-wireless.powersave 2 || true
-    done < <(nmcli -t -f NAME,TYPE connection show 2>/dev/null \
+    # Match on UUID, not name: nmcli's terse output escapes a colon in a
+    # profile name as \:, which splits wrong on -F: and drops the profile, and
+    # two profiles can share a name but never a UUID.
+    local uuid
+    while IFS= read -r uuid; do
+      [[ -n $uuid ]] || continue
+      sudo nmcli connection modify "$uuid" 802-11-wireless.powersave 2 || true
+    done < <(nmcli -t -f UUID,TYPE connection show 2>/dev/null \
              | awk -F: '$2 == "802-11-wireless" { print $1 }')
 
     sudo tee /etc/systemd/system/wifi-powersave-off.service >/dev/null <<'UNIT'

--- a/setup.sh
+++ b/setup.sh
@@ -686,7 +686,7 @@ WantedBy=multi-user.target
 UNIT
     sudo systemctl daemon-reload
     sudo systemctl enable wifi-powersave-off.service
-    sudo systemctl start wifi-powersave-off.service
+    sudo systemctl restart wifi-powersave-off.service
   }
   run "Turning off Wi-Fi power saving" disable_wifi_powersave
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -16,6 +16,9 @@
 #   --rom <file>        ROM filename in $HOME (default: ROM)
 #   --hostname <name>   default: leave unchanged
 #   --perf | --no-perf  enable/disable performance optimizations (default: prompt)
+#   --wifi-powersave | --no-wifi-powersave
+#                       leave the wi-fi radio's power saving alone, or turn it
+#                       off so the Pi stays reachable when idle (default: off)
 #   --debug             show all command output instead of capturing to log
 
 set -euo pipefail
@@ -291,6 +294,7 @@ COLOR_MODE=""
 MODELID=""   # BasiliskII only: 5 (Mac IIci) or 14 (Quadra)
 NEW_HOSTNAME=""
 PERF=""   # "" = prompt, 1 = on, 0 = off
+WIFI_POWERSAVE=0   # 0 = turn the radio's power saving off, 1 = leave it alone
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -307,6 +311,8 @@ while [[ $# -gt 0 ]]; do
     --hostname)      NEW_HOSTNAME=$2; shift 2 ;;
     --perf)          PERF=1; shift ;;
     --no-perf)       PERF=0; shift ;;
+    --wifi-powersave)    WIFI_POWERSAVE=1; shift ;;
+    --no-wifi-powersave) WIFI_POWERSAVE=0; shift ;;
     --debug)         DEBUG=1; shift ;;
     *) die "Unknown option: $1" ;;
   esac
@@ -584,6 +590,7 @@ NEW_HOSTNAME=${NEW_HOSTNAME// /-}
 
 # --- Total step count (for gauge) -----------------------------------------
 TOTAL_STEPS=3   # apt update, apt install, patch_cmdline
+[[ $WIFI_POWERSAVE -eq 0 ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
 [[ -n $NEW_HOSTNAME && $NEW_HOSTNAME != "$CUR_HOSTNAME" ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
 [[ $INSTALL_MACLOCK -eq 1 ]] && TOTAL_STEPS=$((TOTAL_STEPS+5))
 if [[ $INSTALL_SHEEPSHAVER -eq 1 ]]; then
@@ -620,7 +627,7 @@ if [[ -n $NEW_HOSTNAME && $NEW_HOSTNAME != "$CUR_HOSTNAME" ]]; then
 fi
 
 # --- apt packages ---------------------------------------------------------
-APT_PKGS=(curl git)
+APT_PKGS=(curl git iw)
 if [[ $INSTALL_SHEEPSHAVER -eq 1 || $INSTALL_BASILISK -eq 1 ]]; then
   APT_PKGS+=(
     build-essential autoconf automake libtool pkg-config
@@ -643,6 +650,46 @@ patch_cmdline() {
   sudo sed -i 's|$| quiet loglevel=0 vt.global_cursor_default=0 console=tty3 logo.nologo|' "$f"
 }
 run "Configuring quiet boot (cmdline.txt)" patch_cmdline
+
+# --- Wi-Fi power saving ---------------------------------------------------
+# The radio parks itself when nothing is talking to it, so the Pi drops off the
+# network while idle and takes a while to answer again. Turn that off three
+# ways: a NetworkManager default, the saved wi-fi profile, and a boot-time unit
+# for anything NetworkManager does not manage. Applied live with iw as well, so
+# it takes effect without restarting NetworkManager and dropping this session.
+if [[ $WIFI_POWERSAVE -eq 0 ]]; then
+  disable_wifi_powersave() {
+    sudo install -d /etc/NetworkManager/conf.d
+    printf '[connection]\nwifi.powersave = 2\n' \
+      | sudo tee /etc/NetworkManager/conf.d/99-wifi-powersave-off.conf >/dev/null
+
+    local c
+    while IFS= read -r c; do
+      [[ -n $c ]] || continue
+      sudo nmcli connection modify "$c" 802-11-wireless.powersave 2 || true
+    done < <(nmcli -t -f NAME,TYPE connection show 2>/dev/null \
+             | awk -F: '$2 == "802-11-wireless" { print $1 }')
+
+    sudo tee /etc/systemd/system/wifi-powersave-off.service >/dev/null <<'UNIT'
+[Unit]
+Description=Disable Wi-Fi power saving
+Wants=sys-subsystem-net-devices-wlan0.device
+After=sys-subsystem-net-devices-wlan0.device NetworkManager.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=-/usr/sbin/iw dev wlan0 set power_save off
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+    sudo systemctl daemon-reload
+    sudo systemctl enable wifi-powersave-off.service
+    sudo systemctl start wifi-powersave-off.service
+  }
+  run "Turning off Wi-Fi power saving" disable_wifi_powersave
+fi
 
 # --- Performance optimizations -------------------------------------------
 if [[ $PERF -eq 1 ]]; then


### PR DESCRIPTION
The Pi Zero 2 W's radio has power saving on by default. When nothing is talking to it the radio parks, so the Pi drops off the network while idle and is slow to answer when you come back to it.

The installer now turns it off in four places:

- `wifi.powersave = 2` as a NetworkManager default in `/etc/NetworkManager/conf.d/`
- the same on any saved wi-fi profile, so an existing connection picks it up
- a `wifi-powersave-off.service` unit at boot, for setups NetworkManager does not manage
- live via `iw`, so it takes effect immediately

It deliberately does **not** restart NetworkManager. That drops the wi-fi connection, which kills the installer's own ssh session mid-run.

`--wifi-powersave` skips the step and leaves the radio's setting alone.

## Testing

On a Pi Zero 2 W (Raspberry Pi OS trixie, BCM43430), starting from power save on:

```
power save BEFORE: on          power save AFTER:  off
profile BEFORE:    default     profile AFTER:     disable
                               unit:              enabled, active
```

The ssh session running the step stayed up. After a reboot the kernel still reports `brcmfmac: power save disabled` and `iw` reports off.

Flag parsing checked for no flag, `--wifi-powersave`, `--no-wifi-powersave`, and combined with `--perf`.