### PR TITLE
Keep the hostname after a reboot on cloud-init images

### DIFF
--- a/maclock-build/README.md
+++ b/maclock-build/README.md
@@ -234,6 +234,24 @@ The hardware side of the maclock is now done. The [setup script](../setup.sh) in
 
 ## Known Issues
 
+**cloud-init owns the hostname, and `hostnamectl` alone will not stick.** Current Pi OS images ship cloud-init, whose `update_hostname` module runs on *every* boot and rewrites the name from its own config. Set the hostname by hand and it comes back as the old one after a reboot.
+
+Editing `hostname:` in `/boot/firmware/user-data` does not help either. cloud-init caches user-data per instance and does not re-read that file unless the instance ID changes, so it keeps applying the name it first saw. The fix is to tell it to stop managing the hostname:
+
+```bash
+printf 'preserve_hostname: true\n' \
+  | sudo tee /etc/cloud/cloud.cfg.d/99-preserve-hostname.cfg
+sudo hostnamectl set-hostname <your-name>
+```
+
+If `/etc/hosts` still shows the old name as an alias on the `127.0.1.1` line, that is cloud-init's `manage_etc_hosts`, which comes from the image's user-data and outranks anything in `cloud.cfg.d`. Comment the module out of the list in `/etc/cloud/cloud.cfg`:
+
+```
+# - update_etc_hosts
+```
+
+The setup script does all of this for you when you give it a hostname.
+
 **No hardware PWM for the backlight.** The Pi's PWM peripheral has two channels and the analogue audio output uses both of them, so the backlight cannot have one. Enabling a hardware PWM channel does work — the backlight dims perfectly — but it kills sound for the rest of the boot, and disabling it again does not bring sound back:
 
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -627,7 +627,11 @@ if [[ -n $NEW_HOSTNAME && $NEW_HOSTNAME != "$CUR_HOSTNAME" ]]; then
       { print }
       END { if (!seen) print "127.0.1.1\t" name }
     ' /etc/hosts > "$tmp"
-    sudo cp "$tmp" /etc/hosts
+    # Never copy a short write over /etc/hosts: losing it breaks localhost
+    # resolution and every later sudo on a machine with no console.
+    if [[ -s $tmp ]] && grep -qE "^127\.0\.1\.1[[:space:]]" "$tmp"; then
+      sudo cp "$tmp" /etc/hosts
+    fi
     rm -f "$tmp"
 
     # Current Pi OS images ship cloud-init, which rewrites the hostname from

--- a/setup.sh
+++ b/setup.sh
@@ -617,10 +617,36 @@ trap 'stop_gauge' EXIT
 if [[ -n $NEW_HOSTNAME && $NEW_HOSTNAME != "$CUR_HOSTNAME" ]]; then
   set_host() {
     sudo hostnamectl set-hostname "$NEW_HOSTNAME" || return $?
-    if grep -qE "^127\.0\.1\.1[[:space:]]+$CUR_HOSTNAME" /etc/hosts; then
-      sudo sed -i "s/^127\.0\.1\.1[[:space:]]\+$CUR_HOSTNAME.*/127.0.1.1\t$NEW_HOSTNAME/" /etc/hosts
-    else
-      printf '127.0.1.1\t%s\n' "$NEW_HOSTNAME" | sudo tee -a /etc/hosts >/dev/null
+    # Collapse every 127.0.1.1 line into a single one carrying the new name.
+    # Matching on the old hostname instead would append a second line whenever
+    # /etc/hosts and the running hostname disagree, which is exactly what
+    # cloud-init leaves behind.
+    local tmp; tmp=$(mktemp)
+    awk -v name="$NEW_HOSTNAME" '
+      /^127\.0\.1\.1[ \t]/ { if (!seen++) print "127.0.1.1\t" name; next }
+      { print }
+      END { if (!seen) print "127.0.1.1\t" name }
+    ' /etc/hosts > "$tmp"
+    sudo cp "$tmp" /etc/hosts
+    rm -f "$tmp"
+
+    # Current Pi OS images ship cloud-init, which rewrites the hostname from
+    # its own cached config on every boot and puts the old name straight back.
+    # Tell it to leave the hostname alone.
+    [[ -f /etc/cloud/cloud.cfg ]] || return 0
+    sudo install -d /etc/cloud/cloud.cfg.d
+    printf '# Hostname is set locally; do not let cloud-init reset it each boot.\npreserve_hostname: true\n' \
+      | sudo tee /etc/cloud/cloud.cfg.d/99-preserve-hostname.cfg >/dev/null
+
+    # cloud-init also regenerates /etc/hosts when manage_etc_hosts is on, which
+    # re-adds the old short name as an alias. That setting comes from the image's
+    # user-data, which outranks anything dropped in cloud.cfg.d, so switch the
+    # module off instead.
+    if grep -qE '^[[:space:]]*-[[:space:]]+update_etc_hosts[[:space:]]*$' /etc/cloud/cloud.cfg; then
+      [[ -f /etc/cloud/cloud.cfg.orig ]] \
+        || sudo cp /etc/cloud/cloud.cfg /etc/cloud/cloud.cfg.orig
+      sudo sed -i -E 's|^([[:space:]]*)-[[:space:]]+update_etc_hosts[[:space:]]*$|\1# - update_etc_hosts   # disabled by macintosh-mini: /etc/hosts is managed locally|' \
+        /etc/cloud/cloud.cfg
     fi
   }
   run "Setting hostname: $CUR_HOSTNAME → $NEW_HOSTNAME" set_host


### PR DESCRIPTION
Setting a hostname with the installer did not survive a reboot on a current Pi OS image. Two bugs, one of them pre-existing.

## cloud-init puts the old hostname back

Current Pi OS images ship cloud-init. Its `update_hostname` module runs on **every** boot and rewrites the name from its own cached config, so `hostnamectl` alone is undone at the next boot.

Editing `hostname:` in `/boot/firmware/user-data` does not help either — cloud-init caches user-data per instance and will not re-read that file unless the instance ID changes, so it keeps applying the name it first saw. Confirmed on hardware: the file said one thing and cloud-init kept applying another.

The fix is `preserve_hostname: true` in a `cloud.cfg.d` drop-in.

`manage_etc_hosts` then regenerates `/etc/hosts` and re-adds the old short name as an alias on the `127.0.1.1` line. That value comes from the image's user-data, which outranks anything in `cloud.cfg.d`, so a drop-in cannot turn it off — verified, it doesn't. The `update_etc_hosts` module gets commented out of `cloud.cfg` instead, with a one-time `.orig` backup.

Note this leaves `cloud.cfg` as a modified conffile, so apt may prompt about it on a cloud-init upgrade.

## set_host appended a duplicate 127.0.1.1 line

Pre-existing on main. `set_host` only rewrote the `127.0.1.1` line when that line already carried the *current* hostname; otherwise it appended. Whenever `/etc/hosts` and the running hostname disagreed — which cloud-init causes routinely — you got two `127.0.1.1` lines and resolution landed on the stale one.

This surfaced during testing of the change above, and the cloud-init fix makes it worse, because a stale duplicate would now persist instead of being regenerated each boot.

Now every `127.0.1.1` line is collapsed into a single one carrying the new name.

## Verified on a Pi Zero 2 W

Reproduced the original failure, then confirmed the fix end to end:

- From hostname `test`, cloud-init managing both files, duplicate stale hosts lines: after the step and a **reboot**, hostname is correct, exactly one `127.0.1.1` line, services active.
- Two stale duplicate `127.0.1.1` lines collapse to one, other lines and their order preserved, file stays `644 root:root`.
- A file with no `127.0.1.1` line at all gets one appended.
- Re-running the step is a no-op: no double-commenting of the module, no duplicate drop-in.
- The looser `sed` matches the module line under a different indentation and preserves it.

Docs: a Known Issues entry in the maclock DIY guide explaining the trap and the manual fix.