### PR TITLE
Dim the screen from sunset to sunrise

### DIFF
--- a/maclock-build/README.md
+++ b/maclock-build/README.md
@@ -166,6 +166,34 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now brightness-control button-handler
 ```
 
+#### Night dimming (optional)
+
+The dial script can follow the sun. From sunset the backlight runs at half the
+dial level, from 10pm it goes fully dark, and at sunrise it comes back to
+wherever the dial was. Turning the dial at night wakes the screen until the
+next sunset. Sunrise and sunset are computed on the Pi, offline, for the
+reference city of the system timezone (tzdata ships coordinates for every
+zone). The [setup script](../setup.sh) offers a timezone picker if the Pi is
+still on UTC; by hand:
+
+```bash
+sudo timedatectl set-timezone America/New_York   # timedatectl list-timezones
+sudo tee /etc/default/brightness-control >/dev/null <<'EOF'
+NIGHT_DIM=1
+LAT=
+LON=
+NIGHT_FACTOR=0.5
+NIGHT_OFF_AT=22:00
+EOF
+sudo systemctl restart brightness-control
+```
+
+`LAT`/`LON` are optional: fill both in (decimal degrees) if the zone's city is
+far from you. `NIGHT_FACTOR` scales the dial level between sunset and sunrise.
+`NIGHT_OFF_AT` is when the screen goes dark; leave it blank to only ever dim.
+The Pi has no clock battery, so the schedule stays off until NTP has set the
+time.
+
 ---
 
 ### 4. Keep the wi-fi awake

--- a/maclock-build/README.md
+++ b/maclock-build/README.md
@@ -172,9 +172,10 @@ The dial script can follow the sun. From sunset the backlight runs at half the
 dial level, from 10pm it goes fully dark, and at sunrise it comes back to
 wherever the dial was. Turning the dial at night wakes the screen until the
 next sunset. Sunrise and sunset are computed on the Pi, offline, for the
-reference city of the system timezone (tzdata ships coordinates for every
-zone). The [setup script](../setup.sh) offers a timezone picker if the Pi is
-still on UTC; by hand:
+reference city of the system timezone, using the coordinates tzdata ships in
+its zone tables. Stock Pi OS images come set to Europe/London, so check that
+first; the [setup script](../setup.sh) shows the zone and offers a picker. By
+hand:
 
 ```bash
 sudo timedatectl set-timezone America/New_York   # timedatectl list-timezones
@@ -191,8 +192,10 @@ sudo systemctl restart brightness-control
 `LAT`/`LON` are optional: fill both in (decimal degrees) if the zone's city is
 far from you. `NIGHT_FACTOR` scales the dial level between sunset and sunrise.
 `NIGHT_OFF_AT` is when the screen goes dark; leave it blank to only ever dim.
-The Pi has no clock battery, so the schedule stays off until NTP has set the
-time.
+A cutoff earlier than sunset (a midsummer 22:08 sunset under the 22:00
+default) means dark from sunset. In polar night the screen only dims, since
+no sunrise would end the dark. The Pi has no clock battery, so the schedule
+stays off until NTP has set the time.
 
 ---
 

--- a/maclock-build/README.md
+++ b/maclock-build/README.md
@@ -171,9 +171,9 @@ sudo systemctl enable --now brightness-control button-handler
 The dial script can follow the sun. From sunset the backlight runs at half the
 dial level, from 10pm it goes fully dark until an hour before sunrise, and at
 sunrise it comes back to wherever the dial was. Turning the dial at night
-wakes the screen until the next sunset. Sunrise and sunset are computed on the Pi, offline, for the
-reference city of the system timezone, using the coordinates tzdata ships in
-its zone tables. Stock Pi OS images come set to Europe/London, so check that
+wakes the screen until the next sunset. Sunrise and sunset are computed on the
+Pi, offline, for the reference city of the system timezone, using the
+coordinates tzdata ships in its zone tables. Stock Pi OS images come set to Europe/London, so check that
 first; the [setup script](../setup.sh) shows the zone and offers a picker. By
 hand:
 

--- a/maclock-build/README.md
+++ b/maclock-build/README.md
@@ -169,9 +169,9 @@ sudo systemctl enable --now brightness-control button-handler
 #### Night dimming (optional)
 
 The dial script can follow the sun. From sunset the backlight runs at half the
-dial level, from 10pm it goes fully dark, and at sunrise it comes back to
-wherever the dial was. Turning the dial at night wakes the screen until the
-next sunset. Sunrise and sunset are computed on the Pi, offline, for the
+dial level, from 10pm it goes fully dark until an hour before sunrise, and at
+sunrise it comes back to wherever the dial was. Turning the dial at night
+wakes the screen until the next sunset. Sunrise and sunset are computed on the Pi, offline, for the
 reference city of the system timezone, using the coordinates tzdata ships in
 its zone tables. Stock Pi OS images come set to Europe/London, so check that
 first; the [setup script](../setup.sh) shows the zone and offers a picker. By

--- a/maclock-build/brightness-control.service
+++ b/maclock-build/brightness-control.service
@@ -11,6 +11,8 @@ Conflicts=shutdown.target
 
 [Service]
 Type=simple
+# Night dimming schedule; optional, see brightness_control.py
+EnvironmentFile=-/etc/default/brightness-control
 ExecStart=/usr/bin/python3 /usr/local/bin/brightness_control.py
 Restart=always
 RestartSec=2

--- a/maclock-build/brightness_control.py
+++ b/maclock-build/brightness_control.py
@@ -87,10 +87,11 @@ cleaning = False
 #                           timezone's reference city from tzdata, which puts
 #                           sunrise within a few minutes for most people
 #   NIGHT_FACTOR=0.5        sunset to sunrise, the dial level is scaled by this
-#   NIGHT_OFF_AT=22:00      from here until sunrise the backlight goes fully
-#                           dark. Leave blank to only ever dim.
+#   NIGHT_OFF_AT=22:00      from here the backlight goes fully dark, until an
+#                           hour before sunrise. Leave blank to only ever dim.
 # Turning the dial at night wakes the screen until the next sunset.
 NIGHT_FADE_S = 30      # scheduled changes ease in over this long
+WAKE_BEFORE_SUNRISE = timedelta(hours=1)   # dark ends this long before dawn
 NIGHT_CHECK_S = 1.0    # how often the schedule is consulted
 
 # The Zero has no clock battery, so until NTP answers the time is whatever
@@ -239,7 +240,8 @@ def midnight_sun(lat, lon, day):
 def night_factor(now, cfg, sun_times=sun_times):
     """Scale for the dial level at `now` (an aware local datetime).
 
-    1.0 by day, cfg.factor after sunset, 0.0 from cfg.off_at until sunrise.
+    1.0 by day, cfg.factor after sunset, 0.0 from cfg.off_at until an hour
+    before sunrise, then cfg.factor again until the sun is up.
     """
     # Work from the most recent sunrise and sunset instants rather than
     # "today's": where the clock runs far from solar time (Alaska, UTC+14)
@@ -259,6 +261,9 @@ def night_factor(now, cfg, sun_times=sun_times):
         return 1.0
 
     if cfg.off_at is None:
+        return cfg.factor
+    next_rise = min((t for t in rises if t > now), default=None)
+    if next_rise is not None and now >= next_rise - WAKE_BEFORE_SUNRISE:
         return cfg.factor
     # The cutoff belongs to the night that began at last_set: the first
     # occurrence of that clock time from a few hours before sunset on, so a

--- a/maclock-build/brightness_control.py
+++ b/maclock-build/brightness_control.py
@@ -260,19 +260,23 @@ def night_factor(now, cfg, sun_times=sun_times):
     if last_set is None or (last_rise is not None and last_rise > last_set):
         return 1.0
 
-    if cfg.off_at is None:
-        return cfg.factor
     next_rise = min((t for t in rises if t > now), default=None)
-    if next_rise is not None and now >= next_rise - WAKE_BEFORE_SUNRISE:
+    if next_rise is None:
+        # The sun has just stopped rising or setting: the first day of a
+        # polar stretch, with the last sunset still inside the window
+        return 1.0 if midnight_sun(cfg.lat, cfg.lon, now.date()) else cfg.factor
+    if cfg.off_at is None or now >= next_rise - WAKE_BEFORE_SUNRISE:
         return cfg.factor
     # The cutoff belongs to the night that began at last_set: the first
     # occurrence of that clock time from a few hours before sunset on, so a
     # time after midnight lands in this night and one before sunset (a 22:00
-    # cutoff under a 22:08 midsummer sunset) means dark from sunset.
+    # cutoff under a 22:08 midsummer sunset) means dark from sunset. The day
+    # before is a candidate too, for a sunset that itself falls after
+    # midnight (Nome, Reykjavik in June).
     sunset = last_set.astimezone(now.tzinfo)
     off = min(t for t in (datetime.combine(sunset.date() + timedelta(days=days),
                                            cfg.off_at, now.tzinfo)
-                          for days in (0, 1))
+                          for days in (-1, 0, 1))
               if t > sunset - timedelta(hours=6))
     return 0.0 if now >= max(off, sunset) else cfg.factor
 

--- a/maclock-build/brightness_control.py
+++ b/maclock-build/brightness_control.py
@@ -10,11 +10,15 @@
 # March 26, 2026 - http://wells.ee/journal/macintosh-mini
 # ####################################
 
+import math
 import os
+import re
 import signal
 import sys
 import time
 import traceback
+from collections import namedtuple
+from datetime import datetime, time as dtime, timedelta, timezone
 
 try:
     import lgpio
@@ -75,9 +79,192 @@ failed = False
 cleaning = False
 
 
+# --- Night dimming ---
+# Off unless /etc/default/brightness-control turns it on; the systemd unit
+# hands that file over as environment variables:
+#   NIGHT_DIM=1             enable
+#   LAT=40.71 LON=-74.01    optional. Left blank, the location is the system
+#                           timezone's reference city from tzdata, which puts
+#                           sunrise within a few minutes for most people
+#   NIGHT_FACTOR=0.5        sunset to sunrise, the dial level is scaled by this
+#   NIGHT_OFF_AT=22:00      from here until sunrise the backlight goes fully
+#                           dark. Leave blank to only ever dim.
+# Turning the dial at night wakes the screen until the next sunset.
+NIGHT_FADE_S = 30      # scheduled changes ease in over this long
+NIGHT_CHECK_S = 1.0    # how often the schedule is consulted
+
+# The Zero has no clock battery, so until NTP answers the time is whatever
+# fake-hwclock saved at the last shutdown. Dimming on that would be a guess,
+# so the schedule waits for timesyncd to raise this flag.
+CLOCK_SYNCED_FLAG = "/run/systemd/timesync/synchronized"
+
+J2000 = datetime(2000, 1, 1, 12, tzinfo=timezone.utc)
+
+ZONE_TABS = ("/usr/share/zoneinfo/zone1970.tab", "/usr/share/zoneinfo/zone.tab")
+
+NightConfig = namedtuple("NightConfig", "lat lon factor off_at")
+
+
 def write(path, value):
     with open(path, "w") as f:
         f.write(str(value))
+
+
+def read_zone_tab():
+    for path in ZONE_TABS:
+        try:
+            with open(path) as f:
+                return f.read()
+        except OSError:
+            continue
+    return None
+
+
+def zone_coords(zone, tab):
+    """Latitude and longitude of a timezone's reference city, from tzdata's
+    zone1970.tab, or None if the zone is not listed (Etc/UTC, for one)."""
+    if not zone or not tab:
+        return None
+    for line in tab.splitlines():
+        if line.startswith("#"):
+            continue
+        cols = line.split("\t")
+        if len(cols) >= 3 and cols[2] == zone:
+            return _iso6709(cols[1])
+    return None
+
+
+def _iso6709(text):
+    """Decode +DDMM+DDDMM or +DDMMSS+DDDMMSS into decimal degrees."""
+    m = re.fullmatch(r"([+-])(\d{2})(\d{2})(\d{2})?([+-])(\d{3})(\d{2})(\d{2})?", text)
+    if not m:
+        return None
+
+    def decode(sign, d, mi, sec):
+        value = int(d) + int(mi) / 60 + (int(sec) if sec else 0) / 3600
+        return -value if sign == "-" else value
+
+    return (decode(m[1], m[2], m[3], m[4]), decode(m[5], m[6], m[7], m[8]))
+
+
+def system_timezone():
+    # The symlink is what libc and timedatectl agree on; /etc/timezone is a
+    # Debian extra that can lag behind it.
+    target = os.path.realpath("/etc/localtime")
+    if "/zoneinfo/" in target:
+        return target.split("/zoneinfo/", 1)[1]
+    try:
+        with open("/etc/timezone") as f:
+            return f.read().strip() or None
+    except OSError:
+        return None
+
+
+def load_night_config(env, zone=None, zone_tab=None):
+    """Read the night schedule from the environment, or None when it is off."""
+    if env.get("NIGHT_DIM", "0").strip().lower() not in ("1", "true", "yes"):
+        return None
+    if env.get("LAT", "").strip() and env.get("LON", "").strip():
+        lat, lon = float(env["LAT"]), float(env["LON"])
+    else:
+        zone = zone or system_timezone()
+        coords = zone_coords(zone, zone_tab if zone_tab is not None
+                             else read_zone_tab())
+        if coords is None:
+            print(f"No location for timezone {zone!r} and LAT/LON unset; "
+                  "night dimming off. Set the timezone: "
+                  "sudo timedatectl set-timezone <Area/City>", flush=True)
+            return None
+        lat, lon = coords
+    factor = float(env.get("NIGHT_FACTOR", "0.5"))
+    off = env.get("NIGHT_OFF_AT", "22:00").strip()
+    off_at = dtime.fromisoformat(off) if off else None
+    return NightConfig(lat, lon, factor, off_at)
+
+
+def sun_times(lat, lon, day):
+    """Sunrise and sunset on `day` as aware UTC datetimes.
+
+    None where the sun never rises or never sets that day. This is the
+    sunrise equation with NOAA's corrections: good to a couple of minutes,
+    which is plenty for a backlight.
+    """
+    sin, cos, rad = math.sin, math.cos, math.radians
+    # Days since J2000, shifted so the numbers below refer to local solar noon
+    n = (day - J2000.date()).days - lon / 360
+    mean_anomaly = (357.5291 + 0.98560028 * n) % 360
+    centre = (1.9148 * sin(rad(mean_anomaly))
+              + 0.0200 * sin(rad(2 * mean_anomaly))
+              + 0.0003 * sin(rad(3 * mean_anomaly)))
+    ecliptic_lon = (mean_anomaly + centre + 180 + 102.9372) % 360
+    transit = (n + 0.0053 * sin(rad(mean_anomaly))
+               - 0.0069 * sin(rad(2 * ecliptic_lon)))
+    declination = math.asin(sin(rad(ecliptic_lon)) * sin(rad(23.4397)))
+    # -0.833 degrees: the sun's upper limb at the horizon, through refraction
+    cos_hour = ((sin(rad(-0.833)) - sin(rad(lat)) * sin(declination))
+                / (cos(rad(lat)) * cos(declination)))
+    if not -1 <= cos_hour <= 1:
+        return None
+    half_day = math.degrees(math.acos(cos_hour)) / 360
+    return (J2000 + timedelta(days=transit - half_day),
+            J2000 + timedelta(days=transit + half_day))
+
+
+def night_factor(now, cfg, sun_times=sun_times):
+    """Scale for the dial level at `now` (an aware local datetime).
+
+    1.0 by day, cfg.factor after sunset, 0.0 from cfg.off_at until sunrise.
+    """
+    def local(day):
+        times = sun_times(cfg.lat, cfg.lon, day)
+        if times is None:
+            return None
+        return tuple(t.astimezone(now.tzinfo) for t in times)
+
+    today = local(now.date())
+    if today is None:
+        return 1.0
+    rise, set_ = today
+    if rise <= now < set_:
+        return 1.0
+
+    # Which night is this: the one ending at today's sunrise, or the one
+    # starting at today's sunset? The cutoff hangs off the night's start so
+    # a time after midnight still lands in the right night.
+    if now < rise:
+        yesterday = local(now.date() - timedelta(days=1))
+        night_start = yesterday[1] if yesterday else None
+    else:
+        night_start = set_
+    if cfg.off_at is None or night_start is None:
+        return cfg.factor
+    off = datetime.combine(night_start.date(), cfg.off_at, now.tzinfo)
+    if off < night_start:
+        off += timedelta(days=1)
+    return 0.0 if now >= off else cfg.factor
+
+
+def clock_synced():
+    return os.path.exists(CLOCK_SYNCED_FLAG)
+
+
+class NightState:
+    """Applies the schedule, but lets the dial win: a turn at night wakes the
+    screen, and it stays awake until the next sunset."""
+
+    def __init__(self):
+        self.scheduled = 1.0
+        self.awake = False
+
+    def dial_moved(self):
+        if self.scheduled < 1.0:
+            self.awake = True
+
+    def update(self, scheduled):
+        if scheduled == 1.0:
+            self.awake = False
+        self.scheduled = scheduled
+        return 1.0 if self.awake else scheduled
 
 
 def find_pwmchip(timeout=30):
@@ -166,7 +353,10 @@ def main():
     lgpio.gpio_claim_input(h, CLK_PIN, lgpio.SET_PULL_UP)
     lgpio.gpio_claim_input(h, DT_PIN, lgpio.SET_PULL_UP)
 
-    print(f"Brightness control running. level={level}", flush=True)
+    night = load_night_config(os.environ)
+    state = NightState()
+    print(f"Brightness control running. level={level} "
+          f"night={'on' if night else 'off'}", flush=True)
 
     signal.signal(signal.SIGTERM, cleanup)
     signal.signal(signal.SIGINT, cleanup)
@@ -176,6 +366,10 @@ def main():
     last_dir = 0
     last_move = time.monotonic()
     shown = float(level)      # where the backlight is, chasing level
+    factor = 1.0              # what the schedule wants the level scaled by
+    eased = 1.0               # where the scaling is, chasing factor
+    factor_step = POLL_S / NIGHT_FADE_S
+    next_check = 0.0
     last_duty = duty_for(level)
 
     try:
@@ -193,6 +387,10 @@ def main():
                     last_dir = 1 if accum > 0 else -1
                     target = max(0, min(100, level + accum * LEVEL_PER_COUNT))
                     accum = 0
+                    # Any turn wakes the screen at night, even one pinned at
+                    # the end of the dial that leaves the level where it was.
+                    state.dial_moved()
+                    next_check = 0.0
                     if target != level:   # unchanged when pinned at 0 or 100
                         level = target
                         print(f"Level: {level}", flush=True)
@@ -203,15 +401,34 @@ def main():
                 accum = 0
                 last_dir = 0
 
+            if night and time.monotonic() >= next_check:
+                next_check = time.monotonic() + NIGHT_CHECK_S
+                scheduled = 1.0
+                if clock_synced():
+                    scheduled = night_factor(datetime.now().astimezone(), night)
+                wanted = state.update(scheduled)
+                if wanted != factor:
+                    factor = wanted
+                    print(f"Night: x{factor:g}", flush=True)
+                if state.awake:
+                    eased = factor   # the dial was touched: no slow fade
+
+            if eased != factor:
+                if abs(factor - eased) <= factor_step:
+                    eased = factor
+                else:
+                    eased += factor_step if factor > eased else -factor_step
+
             if shown != level:
                 if abs(level - shown) <= RAMP_PER_TICK:
                     shown = float(level)
                 else:
                     shown += RAMP_PER_TICK if level > shown else -RAMP_PER_TICK
-                duty = duty_for(shown)
-                if duty != last_duty:
-                    set_backlight(shown)
-                    last_duty = duty
+
+            duty = duty_for(shown * eased)
+            if duty != last_duty:
+                set_backlight(shown * eased)
+                last_duty = duty
 
             time.sleep(POLL_S)
     except Exception:

--- a/maclock-build/brightness_control.py
+++ b/maclock-build/brightness_control.py
@@ -110,14 +110,19 @@ def write(path, value):
         f.write(str(value))
 
 
-def read_zone_tab():
-    for path in ZONE_TABS:
+def read_zone_tab(paths=ZONE_TABS):
+    """Every zone table tzdata ships, joined. zone1970.tab alone is not
+    enough: since 2022 it folds Oslo, Stockholm, Amsterdam and a hundred
+    others into one representative zone, and only zone.tab still lists
+    them."""
+    tabs = []
+    for path in paths:
         try:
             with open(path) as f:
-                return f.read()
+                tabs.append(f.read())
         except OSError:
             continue
-    return None
+    return "\n".join(tabs) if tabs else None
 
 
 def zone_coords(zone, tab):
@@ -164,6 +169,15 @@ def load_night_config(env, zone=None, zone_tab=None):
     """Read the night schedule from the environment, or None when it is off."""
     if env.get("NIGHT_DIM", "0").strip().lower() not in ("1", "true", "yes"):
         return None
+    try:
+        return _parse_night_config(env, zone, zone_tab)
+    except ValueError as e:
+        # A typo here must not take the dial down in a restart loop
+        print(f"Bad value in night config ({e}); night dimming off", flush=True)
+        return None
+
+
+def _parse_night_config(env, zone, zone_tab):
     if env.get("LAT", "").strip() and env.get("LON", "").strip():
         lat, lon = float(env["LAT"]), float(env["LON"])
     else:
@@ -182,12 +196,12 @@ def load_night_config(env, zone=None, zone_tab=None):
     return NightConfig(lat, lon, factor, off_at)
 
 
-def sun_times(lat, lon, day):
-    """Sunrise and sunset on `day` as aware UTC datetimes.
+def _sun_geometry(lat, lon, day):
+    """Solar transit on `day` in days since J2000, and the cosine of the
+    sunrise hour angle: outside [-1, 1] the sun never crosses the horizon.
 
-    None where the sun never rises or never sets that day. This is the
-    sunrise equation with NOAA's corrections: good to a couple of minutes,
-    which is plenty for a backlight.
+    This is the sunrise equation with NOAA's corrections: good to a couple
+    of minutes, which is plenty for a backlight.
     """
     sin, cos, rad = math.sin, math.cos, math.radians
     # Days since J2000, shifted so the numbers below refer to local solar noon
@@ -203,6 +217,13 @@ def sun_times(lat, lon, day):
     # -0.833 degrees: the sun's upper limb at the horizon, through refraction
     cos_hour = ((sin(rad(-0.833)) - sin(rad(lat)) * sin(declination))
                 / (cos(rad(lat)) * cos(declination)))
+    return transit, cos_hour
+
+
+def sun_times(lat, lon, day):
+    """Sunrise and sunset on `day` as aware UTC datetimes, or None where
+    the sun never rises or never sets that day."""
+    transit, cos_hour = _sun_geometry(lat, lon, day)
     if not -1 <= cos_hour <= 1:
         return None
     half_day = math.degrees(math.acos(cos_hour)) / 360
@@ -210,38 +231,45 @@ def sun_times(lat, lon, day):
             J2000 + timedelta(days=transit + half_day))
 
 
+def midnight_sun(lat, lon, day):
+    """True when the sun stays above the horizon all of `day`."""
+    return _sun_geometry(lat, lon, day)[1] < -1
+
+
 def night_factor(now, cfg, sun_times=sun_times):
     """Scale for the dial level at `now` (an aware local datetime).
 
     1.0 by day, cfg.factor after sunset, 0.0 from cfg.off_at until sunrise.
     """
-    def local(day):
-        times = sun_times(cfg.lat, cfg.lon, day)
-        if times is None:
-            return None
-        return tuple(t.astimezone(now.tzinfo) for t in times)
-
-    today = local(now.date())
-    if today is None:
+    # Work from the most recent sunrise and sunset instants rather than
+    # "today's": where the clock runs far from solar time (Alaska, UTC+14)
+    # the sun can set after local midnight, on the next calendar date.
+    rises, sets = [], []
+    for days in (-1, 0, 1):
+        times = sun_times(cfg.lat, cfg.lon, now.date() + timedelta(days=days))
+        if times is not None:
+            rises.append(times[0])
+            sets.append(times[1])
+    last_rise = max((t for t in rises if t <= now), default=None)
+    last_set = max((t for t in sets if t <= now), default=None)
+    if last_rise is None and last_set is None:
+        # Polar: nothing crossed the horizon for days
+        return 1.0 if midnight_sun(cfg.lat, cfg.lon, now.date()) else cfg.factor
+    if last_set is None or (last_rise is not None and last_rise > last_set):
         return 1.0
-    rise, set_ = today
-    if rise <= now < set_:
-        return 1.0
 
-    # Which night is this: the one ending at today's sunrise, or the one
-    # starting at today's sunset? The cutoff hangs off the night's start so
-    # a time after midnight still lands in the right night.
-    if now < rise:
-        yesterday = local(now.date() - timedelta(days=1))
-        night_start = yesterday[1] if yesterday else None
-    else:
-        night_start = set_
-    if cfg.off_at is None or night_start is None:
+    if cfg.off_at is None:
         return cfg.factor
-    off = datetime.combine(night_start.date(), cfg.off_at, now.tzinfo)
-    if off < night_start:
-        off += timedelta(days=1)
-    return 0.0 if now >= off else cfg.factor
+    # The cutoff belongs to the night that began at last_set: the first
+    # occurrence of that clock time from a few hours before sunset on, so a
+    # time after midnight lands in this night and one before sunset (a 22:00
+    # cutoff under a 22:08 midsummer sunset) means dark from sunset.
+    sunset = last_set.astimezone(now.tzinfo)
+    off = min(t for t in (datetime.combine(sunset.date() + timedelta(days=days),
+                                           cfg.off_at, now.tzinfo)
+                          for days in (0, 1))
+              if t > sunset - timedelta(hours=6))
+    return 0.0 if now >= max(off, sunset) else cfg.factor
 
 
 def clock_synced():
@@ -368,8 +396,8 @@ def main():
     shown = float(level)      # where the backlight is, chasing level
     factor = 1.0              # what the schedule wants the level scaled by
     eased = 1.0               # where the scaling is, chasing factor
-    factor_step = POLL_S / NIGHT_FADE_S
     next_check = 0.0
+    last_tick = time.monotonic()
     last_duty = duty_for(level)
 
     try:
@@ -410,14 +438,20 @@ def main():
                 if wanted != factor:
                     factor = wanted
                     print(f"Night: x{factor:g}", flush=True)
-                if state.awake:
-                    eased = factor   # the dial was touched: no slow fade
+                if state.awake and eased != factor:
+                    # The dial was touched: skip the slow fade and let the
+                    # dial's own quick ramp bring the backlight up
+                    shown *= eased
+                    eased = factor
 
+            now = time.monotonic()
             if eased != factor:
-                if abs(factor - eased) <= factor_step:
+                step = (now - last_tick) / NIGHT_FADE_S
+                if abs(factor - eased) <= step:
                     eased = factor
                 else:
-                    eased += factor_step if factor > eased else -factor_step
+                    eased += step if factor > eased else -step
+            last_tick = now
 
             if shown != level:
                 if abs(level - shown) <= RAMP_PER_TICK:

--- a/maclock-build/test_brightness_control.py
+++ b/maclock-build/test_brightness_control.py
@@ -8,10 +8,13 @@ under test touches GPIO.
 
 import contextlib
 import io
+import os
 import sys
+import tempfile
 import types
 import unittest
 from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 sys.modules.setdefault("lgpio", types.ModuleType("lgpio"))
 
@@ -85,12 +88,60 @@ class NightFactor(unittest.TestCase):
         self.assertEqual(self.factor(self.at(23), off_at=time(1, 0)), 0.5)
         self.assertEqual(self.factor(self.at(1, 30), off_at=time(1, 0)), 0.0)
 
+    def test_cutoff_before_sunset_goes_dark_at_sunset(self):
+        # High-latitude summer: 22:00 comes before a 22:08 sunset. Here the
+        # fixture sets at 18:00, so a 17:00 cutoff stands in for it.
+        self.assertEqual(self.factor(self.at(18, 30), off_at=time(17, 0)), 0.0)
+        self.assertEqual(self.factor(self.at(16, 0), off_at=time(17, 0)), 1.0)
+
     def test_no_cutoff_dims_all_night(self):
         self.assertEqual(self.factor(self.at(3), off_at=None), 0.5)
 
-    def test_polar_day_never_dims(self):
-        cfg = bc.NightConfig(lat=0, lon=0, factor=0.5, off_at=time(22))
-        self.assertEqual(bc.night_factor(self.at(3), cfg, sun_times=lambda *a: None), 1.0)
+
+
+def local_now(zone, y, mo, d, hh, mm=0):
+    """Build `now` the way the daemon sees it on a Pi set to `zone`: an
+    aware datetime carrying a fixed offset, as datetime.now().astimezone()
+    returns."""
+    dt = datetime(y, mo, d, hh, mm, tzinfo=ZoneInfo(zone))
+    return dt.astimezone(timezone(dt.utcoffset()))
+
+
+class NightFactorRealSun(unittest.TestCase):
+    """Real sun_times at places where clock time and solar time disagree."""
+
+    def factor(self, zone, lat, lon, *when, off_at=time(22, 0)):
+        cfg = bc.NightConfig(lat=lat, lon=lon, factor=0.5, off_at=off_at)
+        return bc.night_factor(local_now(zone, *when), cfg)
+
+    def test_stockholm_midsummer_dark_after_late_sunset(self):
+        # Sunset 22:08 CEST is after the 22:00 cutoff: dark from sunset on
+        stockholm = ("Europe/Stockholm", 59.33, 18.07)
+        self.assertEqual(self.factor(*stockholm, 2024, 6, 21, 21, 30), 1.0)
+        self.assertEqual(self.factor(*stockholm, 2024, 6, 21, 22, 30), 0.0)
+        self.assertEqual(self.factor(*stockholm, 2024, 6, 22, 1, 0), 0.0)
+        self.assertEqual(self.factor(*stockholm, 2024, 6, 22, 4, 0), 1.0)
+
+    def test_nome_sunset_after_local_midnight(self):
+        # Alaska's clock runs ~3 h ahead of the sun: June sunset is 01:47
+        nome = ("America/Nome", 64.50, -165.41)
+        self.assertEqual(self.factor(*nome, 2024, 6, 22, 0, 30), 1.0)
+        self.assertEqual(self.factor(*nome, 2024, 6, 22, 2, 30), 0.5)
+        self.assertEqual(self.factor(*nome, 2024, 6, 22, 5, 0), 1.0)
+
+    def test_utc_plus_14_midday_is_day(self):
+        self.assertEqual(self.factor("Pacific/Kiritimati", 1.87, -157.4,
+                                     2024, 6, 21, 12, 0), 1.0)
+
+    def test_polar_night_dims(self):
+        # No sunrise to end a cutoff, so polar night only dims, all day
+        tromso = ("Europe/Oslo", 69.65, 18.96)
+        self.assertEqual(self.factor(*tromso, 2024, 12, 21, 12, 0), 0.5)
+        self.assertEqual(self.factor(*tromso, 2024, 12, 21, 23, 0), 0.5)
+
+    def test_midnight_sun_never_dims(self):
+        self.assertEqual(self.factor("Europe/Oslo", 69.65, 18.96,
+                                     2024, 6, 21, 23, 0), 1.0)
 
 
 class DialOverride(unittest.TestCase):
@@ -133,6 +184,18 @@ class ZoneCoords(unittest.TestCase):
     def test_unknown_zone(self):
         self.assertIsNone(bc.zone_coords("Etc/UTC", ZONE_TAB))
 
+    def test_zone_only_in_second_table_is_found(self):
+        # Since 2022 zone1970.tab folds Oslo, Stockholm, Amsterdam and ~100
+        # others into one representative zone; only zone.tab still lists them.
+        with tempfile.TemporaryDirectory() as d:
+            first = os.path.join(d, "zone1970.tab")
+            second = os.path.join(d, "zone.tab")
+            open(first, "w").write(ZONE_TAB)
+            open(second, "w").write("NO\t+5955+01045\tEurope/Oslo\n")
+            lat, lon = bc.zone_coords("Europe/Oslo", bc.read_zone_tab((first, second)))
+        self.assertAlmostEqual(lat, 59.917, places=3)
+        self.assertAlmostEqual(lon, 10.75, places=3)
+
     def test_real_tzdata_has_coordinates(self):
         # tzdata ships the table this relies on; make sure the parser copes
         # with the real thing, not just the fixture.
@@ -173,6 +236,14 @@ class Config(unittest.TestCase):
     def test_blank_off_at_disables_cutoff(self):
         cfg = self.load({"NIGHT_DIM": "1", "NIGHT_OFF_AT": ""})
         self.assertIsNone(cfg.off_at)
+
+    def test_bad_values_disable_instead_of_crashing(self):
+        # A typo in the config must not take the dial down with a crash loop
+        for bad in ({"NIGHT_FACTOR": "half"}, {"NIGHT_OFF_AT": "10pm"},
+                    {"LAT": "40,7", "LON": "1"}):
+            with contextlib.redirect_stdout(io.StringIO()) as out:
+                self.assertIsNone(self.load({"NIGHT_DIM": "1", **bad}), bad)
+            self.assertIn("night dimming off", out.getvalue())
 
     def test_unknown_timezone_and_no_location_disables(self):
         with contextlib.redirect_stdout(io.StringIO()):

--- a/maclock-build/test_brightness_control.py
+++ b/maclock-build/test_brightness_control.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Tests for the night-dimming logic in brightness_control.py.
+
+Run: python3 -m unittest test_brightness_control
+The lgpio module only exists on the Pi, so it is stubbed out here; nothing
+under test touches GPIO.
+"""
+
+import contextlib
+import io
+import sys
+import types
+import unittest
+from datetime import date, datetime, time, timedelta, timezone
+
+sys.modules.setdefault("lgpio", types.ModuleType("lgpio"))
+
+import brightness_control as bc  # noqa: E402
+
+UTC = timezone.utc
+
+
+def minutes_apart(a, b):
+    return abs((a - b).total_seconds()) / 60
+
+
+class SunTimes(unittest.TestCase):
+    # Reference values from the NOAA solar calculator.
+
+    def test_new_york_summer_solstice(self):
+        rise, set_ = bc.sun_times(40.7128, -74.0060, date(2024, 6, 21))
+        self.assertLess(minutes_apart(rise, datetime(2024, 6, 21, 9, 25, tzinfo=UTC)), 5)
+        self.assertLess(minutes_apart(set_, datetime(2024, 6, 22, 0, 31, tzinfo=UTC)), 5)
+
+    def test_london_winter_solstice(self):
+        rise, set_ = bc.sun_times(51.5074, -0.1278, date(2024, 12, 21))
+        self.assertLess(minutes_apart(rise, datetime(2024, 12, 21, 8, 4, tzinfo=UTC)), 5)
+        self.assertLess(minutes_apart(set_, datetime(2024, 12, 21, 15, 53, tzinfo=UTC)), 5)
+
+    def test_sydney_southern_hemisphere(self):
+        # 2024-06-21: sunrise 07:01 AEST, sunset 16:54 AEST (UTC+10)
+        rise, set_ = bc.sun_times(-33.8688, 151.2093, date(2024, 6, 21))
+        self.assertLess(minutes_apart(rise, datetime(2024, 6, 20, 21, 1, tzinfo=UTC)), 5)
+        self.assertLess(minutes_apart(set_, datetime(2024, 6, 21, 6, 54, tzinfo=UTC)), 5)
+
+    def test_midnight_sun_returns_none(self):
+        self.assertIsNone(bc.sun_times(69.6492, 18.9553, date(2024, 6, 21)))
+
+    def test_polar_night_returns_none(self):
+        self.assertIsNone(bc.sun_times(69.6492, 18.9553, date(2024, 12, 21)))
+
+
+class NightFactor(unittest.TestCase):
+    # A fake location where the sun rises at 06:00 and sets at 18:00 local,
+    # every day, so the tests read as clock times.
+    TZ = timezone(timedelta(hours=-5))
+
+    def sun(self, lat, lon, day):
+        return (datetime.combine(day, time(6), self.TZ).astimezone(UTC),
+                datetime.combine(day, time(18), self.TZ).astimezone(UTC))
+
+    def at(self, hh, mm=0, day=date(2026, 3, 10)):
+        return datetime.combine(day, time(hh, mm), self.TZ)
+
+    def factor(self, now, off_at=time(22, 0), night=0.5):
+        cfg = bc.NightConfig(lat=0, lon=0, factor=night, off_at=off_at)
+        return bc.night_factor(now, cfg, sun_times=self.sun)
+
+    def test_day_is_full_brightness(self):
+        self.assertEqual(self.factor(self.at(12)), 1.0)
+
+    def test_after_sunset_dims(self):
+        self.assertEqual(self.factor(self.at(19)), 0.5)
+
+    def test_after_cutoff_is_dark(self):
+        self.assertEqual(self.factor(self.at(22, 30)), 0.0)
+
+    def test_after_midnight_stays_dark(self):
+        self.assertEqual(self.factor(self.at(3)), 0.0)
+
+    def test_sunrise_restores_full_brightness(self):
+        self.assertEqual(self.factor(self.at(6, 1)), 1.0)
+
+    def test_cutoff_after_midnight(self):
+        self.assertEqual(self.factor(self.at(23), off_at=time(1, 0)), 0.5)
+        self.assertEqual(self.factor(self.at(1, 30), off_at=time(1, 0)), 0.0)
+
+    def test_no_cutoff_dims_all_night(self):
+        self.assertEqual(self.factor(self.at(3), off_at=None), 0.5)
+
+    def test_polar_day_never_dims(self):
+        cfg = bc.NightConfig(lat=0, lon=0, factor=0.5, off_at=time(22))
+        self.assertEqual(bc.night_factor(self.at(3), cfg, sun_times=lambda *a: None), 1.0)
+
+
+class DialOverride(unittest.TestCase):
+    def test_dial_at_night_wakes_until_next_sunset(self):
+        state = bc.NightState()
+        self.assertEqual(state.update(0.5), 0.5)
+        state.dial_moved()
+        self.assertEqual(state.update(0.5), 1.0)   # woken
+        self.assertEqual(state.update(0.0), 1.0)   # still woken past cutoff
+        self.assertEqual(state.update(1.0), 1.0)   # sunrise
+        self.assertEqual(state.update(0.5), 0.5)   # next sunset dims again
+
+    def test_dial_during_day_does_not_pin(self):
+        state = bc.NightState()
+        state.update(1.0)
+        state.dial_moved()
+        self.assertEqual(state.update(0.5), 0.5)
+
+
+ZONE_TAB = """\
+# comment line
+#codes\tcoordinates\tTZ\tcomments
+US\t+404251-0740023\tAmerica/New_York\tEastern (most areas)
+JP\t+353916+1394441\tAsia/Tokyo
+AU\t-3133+15905\tAustralia/Lord_Howe\tLord Howe Island
+"""
+
+
+class ZoneCoords(unittest.TestCase):
+    def test_degrees_minutes_seconds(self):
+        lat, lon = bc.zone_coords("America/New_York", ZONE_TAB)
+        self.assertAlmostEqual(lat, 40.714, places=3)
+        self.assertAlmostEqual(lon, -74.006, places=3)
+
+    def test_degrees_minutes(self):
+        lat, lon = bc.zone_coords("Australia/Lord_Howe", ZONE_TAB)
+        self.assertAlmostEqual(lat, -31.55, places=3)
+        self.assertAlmostEqual(lon, 159.083, places=3)
+
+    def test_unknown_zone(self):
+        self.assertIsNone(bc.zone_coords("Etc/UTC", ZONE_TAB))
+
+    def test_real_tzdata_has_coordinates(self):
+        # tzdata ships the table this relies on; make sure the parser copes
+        # with the real thing, not just the fixture.
+        tab = bc.read_zone_tab()
+        if tab is None:
+            self.skipTest("no tzdata zone table on this machine")
+        lat, lon = bc.zone_coords("Asia/Tokyo", tab)
+        self.assertAlmostEqual(lat, 35.65, places=1)
+        self.assertAlmostEqual(lon, 139.74, places=1)
+
+
+class Config(unittest.TestCase):
+    def load(self, env, zone="America/New_York"):
+        return bc.load_night_config(env, zone=zone, zone_tab=ZONE_TAB)
+
+    def test_disabled_by_default(self):
+        self.assertIsNone(self.load({}))
+
+    def test_location_from_timezone(self):
+        cfg = self.load({"NIGHT_DIM": "1"}, zone="Asia/Tokyo")
+        self.assertAlmostEqual(cfg.lat, 35.654, places=3)
+        self.assertAlmostEqual(cfg.lon, 139.745, places=3)
+
+    def test_explicit_location_overrides_timezone(self):
+        cfg = self.load({"NIGHT_DIM": "1", "LAT": "40.7", "LON": "-74.0",
+                         "NIGHT_FACTOR": "0.4", "NIGHT_OFF_AT": "23:15"}, zone="Asia/Tokyo")
+        self.assertEqual((cfg.lat, cfg.lon, cfg.factor, cfg.off_at),
+                         (40.7, -74.0, 0.4, time(23, 15)))
+
+    def test_blank_location_falls_back_to_timezone(self):
+        cfg = self.load({"NIGHT_DIM": "1", "LAT": "", "LON": ""})
+        self.assertAlmostEqual(cfg.lat, 40.714, places=3)
+
+    def test_defaults(self):
+        cfg = self.load({"NIGHT_DIM": "1"})
+        self.assertEqual((cfg.factor, cfg.off_at), (0.5, time(22, 0)))
+
+    def test_blank_off_at_disables_cutoff(self):
+        cfg = self.load({"NIGHT_DIM": "1", "NIGHT_OFF_AT": ""})
+        self.assertIsNone(cfg.off_at)
+
+    def test_unknown_timezone_and_no_location_disables(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertIsNone(self.load({"NIGHT_DIM": "1"}, zone="Etc/UTC"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/maclock-build/test_brightness_control.py
+++ b/maclock-build/test_brightness_control.py
@@ -129,11 +129,20 @@ class NightFactorRealSun(unittest.TestCase):
         self.assertEqual(self.factor(*stockholm, 2024, 6, 22, 4, 0), 1.0)
 
     def test_nome_sunset_after_local_midnight(self):
-        # Alaska's clock runs ~3 h ahead of the sun: June sunset is 01:47
+        # Alaska's clock runs ~3 h ahead of the sun: June sunset is 01:47,
+        # sunrise 04:19. The 22:00 cutoff came before sunset, so dark from
+        # sunset until 03:19, then dim until sunrise.
         nome = ("America/Nome", 64.50, -165.41)
         self.assertEqual(self.factor(*nome, 2024, 6, 22, 0, 30), 1.0)
-        self.assertEqual(self.factor(*nome, 2024, 6, 22, 2, 30), 0.5)
+        self.assertEqual(self.factor(*nome, 2024, 6, 22, 2, 30), 0.0)
+        self.assertEqual(self.factor(*nome, 2024, 6, 22, 3, 30), 0.5)
         self.assertEqual(self.factor(*nome, 2024, 6, 22, 5, 0), 1.0)
+
+    def test_reykjavik_sunset_minutes_past_midnight(self):
+        # Sunset 00:04, sunrise 02:55: dark from sunset until 01:55
+        rvk = ("Atlantic/Reykjavik", 64.15, -21.94)
+        self.assertEqual(self.factor(*rvk, 2024, 6, 22, 0, 30), 0.0)
+        self.assertEqual(self.factor(*rvk, 2024, 6, 22, 2, 30), 0.5)
 
     def test_utc_plus_14_midday_is_day(self):
         self.assertEqual(self.factor("Pacific/Kiritimati", 1.87, -157.4,
@@ -144,6 +153,15 @@ class NightFactorRealSun(unittest.TestCase):
         tromso = ("Europe/Oslo", 69.65, 18.96)
         self.assertEqual(self.factor(*tromso, 2024, 12, 21, 12, 0), 0.5)
         self.assertEqual(self.factor(*tromso, 2024, 12, 21, 23, 0), 0.5)
+
+    def test_first_day_of_midnight_sun_is_day(self):
+        # The last sunset is still in the window but no sunrise follows it
+        self.assertEqual(self.factor("Europe/Oslo", 69.65, 18.96,
+                                     2024, 5, 18, 12, 0), 1.0)
+
+    def test_first_day_of_polar_night_only_dims(self):
+        self.assertEqual(self.factor("Europe/Oslo", 69.65, 18.96,
+                                     2024, 11, 28, 12, 0), 0.5)
 
     def test_midnight_sun_never_dims(self):
         self.assertEqual(self.factor("Europe/Oslo", 69.65, 18.96,

--- a/maclock-build/test_brightness_control.py
+++ b/maclock-build/test_brightness_control.py
@@ -81,6 +81,11 @@ class NightFactor(unittest.TestCase):
     def test_after_midnight_stays_dark(self):
         self.assertEqual(self.factor(self.at(3)), 0.0)
 
+    def test_dark_ends_an_hour_before_sunrise(self):
+        self.assertEqual(self.factor(self.at(4, 59)), 0.0)
+        self.assertEqual(self.factor(self.at(5, 0)), 0.5)
+        self.assertEqual(self.factor(self.at(5, 59)), 0.5)
+
     def test_sunrise_restores_full_brightness(self):
         self.assertEqual(self.factor(self.at(6, 1)), 1.0)
 
@@ -120,6 +125,7 @@ class NightFactorRealSun(unittest.TestCase):
         self.assertEqual(self.factor(*stockholm, 2024, 6, 21, 21, 30), 1.0)
         self.assertEqual(self.factor(*stockholm, 2024, 6, 21, 22, 30), 0.0)
         self.assertEqual(self.factor(*stockholm, 2024, 6, 22, 1, 0), 0.0)
+        self.assertEqual(self.factor(*stockholm, 2024, 6, 22, 3, 0), 0.5)  # sunrise 03:30
         self.assertEqual(self.factor(*stockholm, 2024, 6, 22, 4, 0), 1.0)
 
     def test_nome_sunset_after_local_midnight(self):

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,13 @@
 #   --wifi-powersave | --no-wifi-powersave
 #                       leave the wi-fi radio's power saving alone, or turn it
 #                       off so the Pi stays reachable when idle (default: off)
+#   --night-dim | --no-night-dim
+#                       dim the screen from sunset to sunrise (default: prompt)
+#   --night-off <t>     when the screen turns off at night: never, or HH:MM
+#                       (default: prompt; 22:00 on a fresh install)
+#   --timezone <zone>   Area/City for the sunrise schedule (default: keep, or
+#                       prompt when the Pi is still on UTC)
+#   --branch <name>     fetch the helper files from a branch other than main
 #   --debug             show all command output instead of capturing to log
 
 set -euo pipefail
@@ -658,7 +665,9 @@ conf_get() { { sed -n "s/^$1=//p" "$NIGHT_CONF" | head -1; } 2>/dev/null || true
 current_timezone() {
   local tz
   tz=$(timedatectl show -p Timezone --value 2>/dev/null) || tz=$(cat /etc/timezone 2>/dev/null) || true
-  case "$tz" in ""|UTC|Etc/UTC|Universal|Etc/Universal|GMT|Etc/GMT) return 1 ;; esac
+  # Etc/* zones (UTC, GMT+5 ...) have no city, so no place to compute a
+  # sunrise for
+  case "$tz" in ""|UTC|Universal|GMT|Etc/*) return 1 ;; esac
   printf '%s' "$tz"
 }
 
@@ -684,6 +693,9 @@ pick_timezone() {
 if [[ -n $TIMEZONE && ! -f /usr/share/zoneinfo/$TIMEZONE ]]; then
   die "Unknown timezone: $TIMEZONE (see: timedatectl list-timezones)"
 fi
+if [[ -n $NIGHT_OFF && ! $NIGHT_OFF =~ ^(never|([01][0-9]|2[0-3]):[0-5][0-9])$ ]]; then
+  die "--night-off takes 'never' or HH:MM, not '$NIGHT_OFF'"
+fi
 if [[ $INSTALL_MACLOCK -eq 1 && $UPDATE_MODE != quick ]]; then
   if [[ -z $NIGHT_DIM ]]; then
     # Stock Pi OS images ship Europe/London, so a zone that looks set may
@@ -708,15 +720,20 @@ Useful if your Macintosh Mini is a desk accessory or display piece." "$cur" 3 \
     pick_timezone || die "Cancelled"
   fi
   if [[ $NIGHT_DIM -eq 1 && -z $NIGHT_OFF ]]; then
-    case "$(conf_get NIGHT_OFF_AT)" in
+    # A hand-edited time that is not one of the presets gets its own entry,
+    # so pressing Enter keeps it
+    off_now=$(conf_get NIGHT_OFF_AT); keep=()
+    case "$off_now" in
       21:00) cur="9 PM" ;;  22:00) cur="10 PM" ;;  23:00) cur="11 PM" ;;
       00:00) cur="12 AM" ;; 01:00) cur="1 AM" ;;
-      *) if grep -q '^NIGHT_OFF_AT=$' "$NIGHT_CONF" 2>/dev/null; then cur=Never; else cur="10 PM"; fi ;;
+      "") if grep -q '^NIGHT_OFF_AT=$' "$NIGHT_CONF" 2>/dev/null; then cur=Never; else cur="10 PM"; fi ;;
+      *) cur="Keep $off_now"; keep=("$cur" "") ;;
     esac
     OFF_CHOICE=$(wt_menu "Night Dimming" "Do you want your screen to turn off at night?
-(It comes back on 1 hour before sunrise.)" "$cur" 6 \
-      "Never" "" "9 PM" "" "10 PM" "" "11 PM" "" "12 AM" "" "1 AM" "") || die "Cancelled"
+(It comes back on 1 hour before sunrise.)" "$cur" $(( 6 + ${#keep[@]} / 2 )) \
+      "Never" "" "9 PM" "" "10 PM" "" "11 PM" "" "12 AM" "" "1 AM" "" ${keep[@]+"${keep[@]}"}) || die "Cancelled"
     case "$OFF_CHOICE" in
+      Keep*)   NIGHT_OFF=$off_now ;;
       Never)   NIGHT_OFF=never ;;
       "9 PM")  NIGHT_OFF=21:00 ;;
       "10 PM") NIGHT_OFF=22:00 ;;
@@ -729,7 +746,7 @@ fi
 
 
 # --- Total step count (for gauge) -----------------------------------------
-TOTAL_STEPS=3   # apt update, apt install, patch_cmdline
+TOTAL_STEPS=4   # apt update, apt install, patch_cmdline, record_install
 [[ $WIFI_POWERSAVE -eq 0 ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
 [[ -n $NEW_HOSTNAME && $NEW_HOSTNAME != "$CUR_HOSTNAME" ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
 [[ -n $TIMEZONE ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
@@ -1012,7 +1029,8 @@ LAT=$lat
 LON=$lon
 # Sunset to sunrise, the dial level is multiplied by this
 NIGHT_FACTOR=$factor
-# From this time until sunrise the screen goes fully dark. Blank to only dim.
+# From this time the screen goes fully dark, until an hour before sunrise.
+# Blank to only dim.
 NIGHT_OFF_AT=$off_at
 EOF
   }
@@ -1414,7 +1432,7 @@ record_install() {
   printf 'VERSION=%s\nMACLOCK=%s\nEMULATOR=%s\nPERF=%s\n' \
     "$VERSION" "$maclock" "$emulator" "${PERF:-0}" | sudo tee "$INSTALL_STATE" >/dev/null
 }
-record_install
+run "Recording the install" record_install
 
 # --- Done -----------------------------------------------------------------
 emit_gauge 100 "Done"

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,8 @@
 
 set -euo pipefail
 
-REPO_RAW="https://raw.githubusercontent.com/wr/macintosh-mini/main"
+REPO_BRANCH="main"   # --branch: test an unmerged branch on a real Pi
+REPO_RAW="https://raw.githubusercontent.com/wr/macintosh-mini/$REPO_BRANCH"
 VERSION="1.1.0"
 
 # SheepShaver paths (DISK_IMAGE is auto-discovered or set via --disk)
@@ -295,6 +296,9 @@ MODELID=""   # BasiliskII only: 5 (Mac IIci) or 14 (Quadra)
 NEW_HOSTNAME=""
 PERF=""   # "" = prompt, 1 = on, 0 = off
 WIFI_POWERSAVE=0   # 0 = turn the radio's power saving off, 1 = leave it alone
+NIGHT_DIM=""       # "" = prompt, 1 = dim the screen at night, 0 = don't
+TIMEZONE=""        # Area/City to set; the night schedule needs a real one
+NIGHT_CONF=/etc/default/brightness-control
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -313,6 +317,10 @@ while [[ $# -gt 0 ]]; do
     --no-perf)       PERF=0; shift ;;
     --wifi-powersave)    WIFI_POWERSAVE=1; shift ;;
     --no-wifi-powersave) WIFI_POWERSAVE=0; shift ;;
+    --night-dim)     NIGHT_DIM=1; shift ;;
+    --no-night-dim)  NIGHT_DIM=0; shift ;;
+    --timezone)      TIMEZONE=$2; shift 2 ;;
+    --branch)        REPO_BRANCH=$2; REPO_RAW="https://raw.githubusercontent.com/wr/macintosh-mini/$REPO_BRANCH"; shift 2 ;;
     --debug)         DEBUG=1; shift ;;
     *) die "Unknown option: $1" ;;
   esac
@@ -587,11 +595,55 @@ if [[ -z $NEW_HOSTNAME ]]; then
 fi
 NEW_HOSTNAME=${NEW_HOSTNAME// /-}
 
+# Night dimming (maclock only). Sunset to sunrise the backlight runs at half
+# the dial level and goes dark from NIGHT_OFF_AT; see brightness_control.py.
+# The script takes its location from the timezone, so a Pi still on UTC gets
+# a picker like raspi-config's. A re-run defaults to whatever the last run chose.
+conf_get() { sed -n "s/^$1=//p" "$NIGHT_CONF" 2>/dev/null | head -1; }
+
+current_timezone() {
+  local tz
+  tz=$(timedatectl show -p Timezone --value 2>/dev/null) || tz=$(cat /etc/timezone 2>/dev/null) || true
+  case "$tz" in ""|UTC|Etc/UTC|Universal|Etc/Universal|GMT|Etc/GMT) return 1 ;; esac
+  printf '%s' "$tz"
+}
+
+pick_timezone() {
+  # zone1970.tab lists every Area/City tzdata knows, one per line
+  local tab=/usr/share/zoneinfo/zone1970.tab
+  [[ -f $tab ]] || tab=/usr/share/zoneinfo/zone.tab
+  [[ -f $tab ]] || die "No tzdata zone table at /usr/share/zoneinfo"
+  local areas=() cities=() item area city
+  while read -r item; do areas+=("$item" ""); done \
+    < <(awk -F'\t' '!/^#/ { split($3, p, "/"); print p[1] }' "$tab" | sort -u)
+  area=$(wt_menu "Timezone" "The Pi is on UTC. Pick your area:" "${areas[0]}" 12 "${areas[@]}") \
+    || return 1
+  while read -r item; do cities+=("$item" ""); done \
+    < <(awk -F'\t' -v a="$area/" '!/^#/ && index($3, a) == 1 { print substr($3, length(a) + 1) }' "$tab" | sort)
+  city=$(wt_menu "Timezone" "Pick the nearest city in $area:" "${cities[0]}" 14 "${cities[@]}") \
+    || return 1
+  TIMEZONE="$area/$city"
+}
+
+if [[ $INSTALL_MACLOCK -eq 1 ]]; then
+  if [[ -z $NIGHT_DIM ]]; then
+    cur=No; [[ $(conf_get NIGHT_DIM) == 1 ]] && cur=Yes
+    NIGHT_CHOICE=$(wt_menu "Night Dimming" "" "$cur" 2 \
+      "Yes"  "Dim the screen at sunset, dark from 10pm, back at sunrise" \
+      "No"   "Leave brightness to the dial") || die "Cancelled"
+    case "$NIGHT_CHOICE" in Yes) NIGHT_DIM=1 ;; No) NIGHT_DIM=0 ;; esac
+  fi
+  if [[ $NIGHT_DIM -eq 1 && -z $TIMEZONE ]] && ! current_timezone >/dev/null; then
+    pick_timezone || die "Cancelled"
+  fi
+fi
+
 
 # --- Total step count (for gauge) -----------------------------------------
 TOTAL_STEPS=3   # apt update, apt install, patch_cmdline
 [[ $WIFI_POWERSAVE -eq 0 ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
 [[ -n $NEW_HOSTNAME && $NEW_HOSTNAME != "$CUR_HOSTNAME" ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
+[[ -n $TIMEZONE ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
 [[ $INSTALL_MACLOCK -eq 1 ]] && TOTAL_STEPS=$((TOTAL_STEPS+5))
 if [[ $INSTALL_SHEEPSHAVER -eq 1 ]]; then
   if [[ -x /usr/local/bin/SheepShaver ]]; then
@@ -654,6 +706,12 @@ if [[ -n $NEW_HOSTNAME && $NEW_HOSTNAME != "$CUR_HOSTNAME" ]]; then
     fi
   }
   run "Setting hostname: $CUR_HOSTNAME → $NEW_HOSTNAME" set_host
+fi
+
+# --- Timezone -------------------------------------------------------------
+if [[ -n $TIMEZONE ]]; then
+  [[ -f /usr/share/zoneinfo/$TIMEZONE ]] || die "Unknown timezone: $TIMEZONE"
+  run "Setting timezone: $TIMEZONE" sudo timedatectl set-timezone "$TIMEZONE"
 fi
 
 # --- apt packages ---------------------------------------------------------
@@ -839,6 +897,34 @@ EOF
   }
   run "[maclock] Patching config.txt" patch_config
 
+  write_night_conf() {
+    [[ -n $NIGHT_DIM ]] || return 0
+    local lat lon factor off_at
+    # A hand-set location survives re-runs
+    lat=$(conf_get LAT); lon=$(conf_get LON)
+    factor=$(conf_get NIGHT_FACTOR); factor=${factor:-0.5}
+    # Blank is a valid setting (dim, never dark), so only fall back to the
+    # default when the key is absent entirely.
+    if grep -q '^NIGHT_OFF_AT=' "$NIGHT_CONF" 2>/dev/null; then
+      off_at=$(conf_get NIGHT_OFF_AT)
+    else
+      off_at=22:00
+    fi
+    sudo tee "$NIGHT_CONF" >/dev/null <<EOF
+# Night dimming for the maclock backlight. Read by brightness-control.service;
+# after editing: sudo systemctl restart brightness-control
+NIGHT_DIM=$NIGHT_DIM
+# Optional. Blank, the location is the timezone's reference city from tzdata.
+# Set both in decimal degrees (north and east positive) for a closer fix.
+LAT=$lat
+LON=$lon
+# Sunset to sunrise, the dial level is multiplied by this
+NIGHT_FACTOR=$factor
+# From this time until sunrise the screen goes fully dark. Blank to only dim.
+NIGHT_OFF_AT=$off_at
+EOF
+  }
+
   install_gpio_helpers() {
     for f in brightness_control.py button_handler.py; do
       curl -fL --retry 3 -o "/tmp/$f" "$REPO_RAW/maclock-build/$f" || return $?
@@ -848,12 +934,15 @@ EOF
       curl -fL --retry 3 -o "/tmp/$f" "$REPO_RAW/maclock-build/$f" || return $?
       sudo install -m644 "/tmp/$f" "/etc/systemd/system/$f" || return $?
     done
+    write_night_conf || return $?
     sudo systemctl daemon-reload
     # reenable, not enable: the unit moved from multi-user.target to
     # sysinit.target, and plain enable only adds the new symlink.
     sudo systemctl reenable brightness-control.service button-handler.service
-    sudo systemctl start brightness-control.service button-handler.service
+    # restart, not start: on an update the old script is still running
+    sudo systemctl restart brightness-control.service button-handler.service
   }
+
   run "[maclock] Installing GPIO helpers + systemd units" install_gpio_helpers
 
   install_restart_wrapper() {

--- a/setup.sh
+++ b/setup.sh
@@ -72,6 +72,8 @@ dump_log_on_failure() {
 # --- Progress gauge --------------------------------------------------------
 PROGRESS_FIFO=""
 GAUGE_PID=""
+GAUGE_NOTE="This will take a while. Go make yourself a coffee :)
+Your device will automatically reboot when finished."
 USE_GAUGE=0
 TOTAL_STEPS=1
 CURRENT_STEP=0
@@ -81,7 +83,9 @@ start_gauge() {
   PROGRESS_FIFO=$(mktemp -u /tmp/macintosh-mini-progress.XXXXXX)
   mkfifo "$PROGRESS_FIFO"
   whiptail --backtitle "macintosh-mini" --title "Installing" \
-    --gauge "Starting…" 8 72 0 < "$PROGRESS_FIFO" &
+    --gauge "$GAUGE_NOTE
+
+Starting…" 11 72 0 < "$PROGRESS_FIFO" &
   GAUGE_PID=$!
   exec 9> "$PROGRESS_FIFO"
   USE_GAUGE=1
@@ -98,7 +102,7 @@ stop_gauge() {
 emit_gauge() {
   local pct=$1 msg=$2
   [[ $USE_GAUGE -eq 1 ]] || return 0
-  printf 'XXX\n%s\n%s\nXXX\n' "$pct" "$msg" >&9
+  printf 'XXX\n%s\n%s\n\n%s\nXXX\n' "$pct" "$GAUGE_NOTE" "$msg" >&9
 }
 
 step_pct() { echo $(( CURRENT_STEP * 100 / TOTAL_STEPS )); }
@@ -168,6 +172,7 @@ wt_menu() {
   local title=$1 prompt=$2 default=$3 list_height=$4
   shift 4
   local extra=8; [[ -z $prompt ]] && extra=7
+  local newlines=${prompt//[!$'\n']/}; extra=$(( extra + ${#newlines} ))
   local total_height=$(( list_height + extra ))
   whiptail --backtitle "macintosh-mini" --title "$title" \
     --default-item "$default" \
@@ -297,6 +302,7 @@ NEW_HOSTNAME=""
 PERF=""   # "" = prompt, 1 = on, 0 = off
 WIFI_POWERSAVE=0   # 0 = turn the radio's power saving off, 1 = leave it alone
 NIGHT_DIM=""       # "" = prompt, 1 = dim the screen at night, 0 = don't
+NIGHT_OFF=""       # "" = prompt, "never", or HH:MM to turn the screen off
 TIMEZONE=""        # Area/City to set; the night schedule needs a real one
 NIGHT_CONF=/etc/default/brightness-control
 
@@ -319,6 +325,7 @@ while [[ $# -gt 0 ]]; do
     --no-wifi-powersave) WIFI_POWERSAVE=0; shift ;;
     --night-dim)     NIGHT_DIM=1; shift ;;
     --no-night-dim)  NIGHT_DIM=0; shift ;;
+    --night-off)     NIGHT_OFF=$2; shift 2 ;;
     --timezone)      TIMEZONE=$2; shift 2 ;;
     --branch)        REPO_BRANCH=$2; REPO_RAW="https://raw.githubusercontent.com/wr/macintosh-mini/$REPO_BRANCH"; shift 2 ;;
     --debug)         DEBUG=1; shift ;;
@@ -599,7 +606,7 @@ NEW_HOSTNAME=${NEW_HOSTNAME// /-}
 # the dial level and goes dark from NIGHT_OFF_AT; see brightness_control.py.
 # The script takes its location from the timezone, so a Pi still on UTC gets
 # a picker like raspi-config's. A re-run defaults to whatever the last run chose.
-conf_get() { sed -n "s/^$1=//p" "$NIGHT_CONF" 2>/dev/null | head -1; }
+conf_get() { { sed -n "s/^$1=//p" "$NIGHT_CONF" | head -1; } 2>/dev/null || true; }
 
 current_timezone() {
   local tz
@@ -632,23 +639,43 @@ if [[ -n $TIMEZONE && ! -f /usr/share/zoneinfo/$TIMEZONE ]]; then
 fi
 if [[ $INSTALL_MACLOCK -eq 1 ]]; then
   if [[ -z $NIGHT_DIM ]]; then
-    cur=No; [[ $(conf_get NIGHT_DIM) == 1 ]] && cur=Yes
-    tz=${TIMEZONE:-$(current_timezone || echo "not set")}
     # Stock Pi OS images ship Europe/London, so a zone that looks set may
     # not be. Show it and offer the picker either way.
-    NIGHT_CHOICE=$(wt_menu "Night Dimming" "Sunset to sunrise the screen dims; from 10pm it goes dark." "$cur" 3 \
-      "Yes"       "Follow the sun for the timezone: $tz" \
-      "Timezone"  "Same, but pick the timezone first" \
-      "No"        "Leave brightness to the dial") || die "Cancelled"
+    tz=${TIMEZONE:-$(current_timezone || echo "not set")}
+    yes_tag="Yes (timezone: $tz)"
+    cur=No; [[ $(conf_get NIGHT_DIM) == 1 ]] && cur=$yes_tag
+    NIGHT_CHOICE=$(wt_menu "Night Dimming" \
+      "Do you want your screen to dim automatically from sunset to sunrise?
+Useful if your Macintosh Mini is a desk accessory or display piece." "$cur" 3 \
+      "$yes_tag"          "" \
+      "Update timezone"   "" \
+      "No"                "") || die "Cancelled"
     case "$NIGHT_CHOICE" in
-      Yes)      NIGHT_DIM=1 ;;
-      Timezone) NIGHT_DIM=1; pick_timezone || die "Cancelled" ;;
-      No)       NIGHT_DIM=0 ;;
+      "Yes"*)            NIGHT_DIM=1 ;;
+      "Update timezone") NIGHT_DIM=1; pick_timezone || die "Cancelled" ;;
+      No)                NIGHT_DIM=0 ;;
     esac
   fi
   # The schedule needs a real zone: UTC has no reference city
   if [[ $NIGHT_DIM -eq 1 && -z $TIMEZONE ]] && ! current_timezone >/dev/null; then
     pick_timezone || die "Cancelled"
+  fi
+  if [[ $NIGHT_DIM -eq 1 && -z $NIGHT_OFF ]]; then
+    case "$(conf_get NIGHT_OFF_AT)" in
+      21:00) cur="9 PM" ;;  22:00) cur="10 PM" ;;  23:00) cur="11 PM" ;;
+      00:00) cur="12 AM" ;; 01:00) cur="1 AM" ;;
+      *) if grep -q '^NIGHT_OFF_AT=$' "$NIGHT_CONF" 2>/dev/null; then cur=Never; else cur="10 PM"; fi ;;
+    esac
+    OFF_CHOICE=$(wt_menu "Night Dimming" "Do you want your screen to turn off at night?" "$cur" 6 \
+      "Never" "" "9 PM" "" "10 PM" "" "11 PM" "" "12 AM" "" "1 AM" "") || die "Cancelled"
+    case "$OFF_CHOICE" in
+      Never)   NIGHT_OFF=never ;;
+      "9 PM")  NIGHT_OFF=21:00 ;;
+      "10 PM") NIGHT_OFF=22:00 ;;
+      "11 PM") NIGHT_OFF=23:00 ;;
+      "12 AM") NIGHT_OFF=00:00 ;;
+      "1 AM")  NIGHT_OFF=01:00 ;;
+    esac
   fi
 fi
 
@@ -916,9 +943,13 @@ EOF
     # A hand-set location survives re-runs
     lat=$(conf_get LAT); lon=$(conf_get LON)
     factor=$(conf_get NIGHT_FACTOR); factor=${factor:-0.5}
-    # Blank is a valid setting (dim, never dark), so only fall back to the
-    # default when the key is absent entirely.
-    if grep -q '^NIGHT_OFF_AT=' "$NIGHT_CONF" 2>/dev/null; then
+    if [[ $NIGHT_OFF == never ]]; then
+      off_at=""
+    elif [[ -n $NIGHT_OFF ]]; then
+      off_at=$NIGHT_OFF
+    elif grep -q '^NIGHT_OFF_AT=' "$NIGHT_CONF" 2>/dev/null; then
+      # Blank is a valid setting (dim, never dark), so only fall back to
+      # the default when the key is absent entirely.
       off_at=$(conf_get NIGHT_OFF_AT)
     else
       off_at=22:00

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 
 REPO_BRANCH="main"   # --branch: test an unmerged branch on a real Pi
 REPO_RAW="https://raw.githubusercontent.com/wr/macintosh-mini/$REPO_BRANCH"
-VERSION="1.1.0"
+VERSION="1.2.0"
 
 # SheepShaver paths (DISK_IMAGE is auto-discovered or set via --disk)
 DISK_IMAGE=""
@@ -72,7 +72,8 @@ dump_log_on_failure() {
 # --- Progress gauge --------------------------------------------------------
 PROGRESS_FIFO=""
 GAUGE_PID=""
-GAUGE_NOTE="This will take a while. Go make yourself a coffee :)
+GAUGE_NOTE="
+This will take a while. Go make yourself a coffee :)
 Your device will automatically reboot when finished."
 USE_GAUGE=0
 TOTAL_STEPS=1
@@ -347,6 +348,49 @@ printf '  log: %s%s\n' "$LOG_FILE" "$([[ $DEBUG -eq 1 ]] && echo '  [debug mode:
 ensure_sudo
 ensure_whiptail
 
+# --- Existing install? -----------------------------------------------------
+# The installer records what it set up so a re-run knows it is an update.
+# Installs before 1.2.0 left no record, so fall back to what is on disk.
+INSTALL_STATE=/etc/macintosh-mini.conf
+state_get() { { sed -n "s/^$1=//p" "$INSTALL_STATE" | head -1; } 2>/dev/null || true; }
+INSTALLED_VERSION=$(state_get VERSION)
+INSTALLED_MACLOCK=$(state_get MACLOCK)
+INSTALLED_EMULATOR=$(state_get EMULATOR)
+INSTALLED_PERF=$(state_get PERF)
+if [[ -z $INSTALLED_VERSION ]]; then
+  [[ -f /etc/systemd/system/brightness-control.service ]] && INSTALLED_MACLOCK=1
+  grep -qsF "# >>> basilisk-autostart >>>" "$HOME/.profile" && INSTALLED_EMULATOR=basilisk
+  grep -qsF "# >>> sheepshaver-autostart >>>" "$HOME/.profile" && INSTALLED_EMULATOR=sheepshaver
+  grep -qs "fsck.mode=skip" /boot/firmware/cmdline.txt && INSTALLED_PERF=1
+fi
+
+UPDATE_MODE=""   # "" = fresh install or flags given, quick = keep settings, edit = re-prompt
+if [[ $INSTALL_MACLOCK -eq 0 && $INSTALL_SHEEPSHAVER -eq 0 && $INSTALL_BASILISK -eq 0 \
+      && ( -n $INSTALLED_MACLOCK || -n $INSTALLED_EMULATOR ) ]]; then
+  opt_up="Update to version $VERSION"
+  opt_edit="Update and edit settings"
+  CHOICE=$(wt_menu "Macintosh Mini Installer v$VERSION" \
+    "Version ${INSTALLED_VERSION:-1.1.0 or earlier} is installed." "$opt_up" 3 \
+    "$opt_up"   "" \
+    "$opt_edit" "" \
+    "Exit"      "") || exit 0
+  case "$CHOICE" in
+    "$opt_up")   UPDATE_MODE=quick ;;
+    "$opt_edit") UPDATE_MODE=edit ;;
+    *)           exit 0 ;;
+  esac
+  [[ $INSTALLED_MACLOCK == 1 ]] && INSTALL_MACLOCK=1
+  case "$INSTALLED_EMULATOR" in
+    basilisk)    INSTALL_BASILISK=1 ;;
+    sheepshaver) INSTALL_SHEEPSHAVER=1 ;;
+  esac
+  if [[ $UPDATE_MODE == quick ]]; then
+    # Keep every setting: no prompts, nothing rewritten
+    [[ -z $PERF ]] && PERF=${INSTALLED_PERF:-0}
+    [[ -z $NEW_HOSTNAME ]] && NEW_HOSTNAME=$(hostname)
+  fi
+fi
+
 # --- Whiptail prompts ------------------------------------------------------
 if [[ $INSTALL_MACLOCK -eq 0 && $INSTALL_SHEEPSHAVER -eq 0 && $INSTALL_BASILISK -eq 0 ]]; then
   # Single-column menu (label = tag, blank item).
@@ -580,7 +624,9 @@ configure_existing() {  # $1=prefs  $2=is_basilisk
   done
 }
 
-if [[ $NEED_PREFS -eq 0 && $INSTALL_BASILISK -eq 1 ]]; then
+if [[ $UPDATE_MODE == quick ]]; then
+  :
+elif [[ $NEED_PREFS -eq 0 && $INSTALL_BASILISK -eq 1 ]]; then
   configure_existing "$HOME/.basilisk_ii_prefs" 1
 elif [[ $NEED_PREFS -eq 0 && $INSTALL_SHEEPSHAVER -eq 1 ]]; then
   configure_existing "$HOME/.sheepshaver_prefs" 0
@@ -588,7 +634,8 @@ fi
 
 # Performance optimizations
 if [[ -z $PERF ]]; then
-  PERF_CHOICE=$(wt_menu "Performance Optimizations" "" "Yes" 2 \
+  def=Yes; [[ ${INSTALLED_PERF:-1} == 0 ]] && def=No
+  PERF_CHOICE=$(wt_menu "Performance Optimizations" "" "$def" 2 \
     "Yes"  "Faster — more RAM, fewer background services" \
     "No"   "Stock install") || die "Cancelled"
   case "$PERF_CHOICE" in Yes) PERF=1 ;; No) PERF=0 ;; esac
@@ -637,7 +684,7 @@ pick_timezone() {
 if [[ -n $TIMEZONE && ! -f /usr/share/zoneinfo/$TIMEZONE ]]; then
   die "Unknown timezone: $TIMEZONE (see: timedatectl list-timezones)"
 fi
-if [[ $INSTALL_MACLOCK -eq 1 ]]; then
+if [[ $INSTALL_MACLOCK -eq 1 && $UPDATE_MODE != quick ]]; then
   if [[ -z $NIGHT_DIM ]]; then
     # Stock Pi OS images ship Europe/London, so a zone that looks set may
     # not be. Show it and offer the picker either way.
@@ -666,7 +713,7 @@ Useful if your Macintosh Mini is a desk accessory or display piece." "$cur" 3 \
       00:00) cur="12 AM" ;; 01:00) cur="1 AM" ;;
       *) if grep -q '^NIGHT_OFF_AT=$' "$NIGHT_CONF" 2>/dev/null; then cur=Never; else cur="10 PM"; fi ;;
     esac
-    OFF_CHOICE=$(wt_menu "Night Dimming" "Do you want your screen to turn off at night?" "$cur" 6 \
+    OFF_CHOICE=$(wt_menu "Night Dimming" "Do you want your screen to turn off at night (until 1 hour before sunrise)?" "$cur" 6 \
       "Never" "" "9 PM" "" "10 PM" "" "11 PM" "" "12 AM" "" "1 AM" "") || die "Cancelled"
     case "$OFF_CHOICE" in
       Never)   NIGHT_OFF=never ;;
@@ -1356,6 +1403,17 @@ EOF
   }
   run "[basilisk] Appending autostart to ~/.profile" patch_profile_basilisk
 fi
+
+# --- Record what was installed, so the next run knows it is an update -----
+record_install() {
+  local emulator=$INSTALLED_EMULATOR maclock=${INSTALLED_MACLOCK:-0}
+  [[ $INSTALL_BASILISK -eq 1 ]] && emulator=basilisk
+  [[ $INSTALL_SHEEPSHAVER -eq 1 ]] && emulator=sheepshaver
+  [[ $INSTALL_MACLOCK -eq 1 ]] && maclock=1
+  printf 'VERSION=%s\nMACLOCK=%s\nEMULATOR=%s\nPERF=%s\n' \
+    "$VERSION" "$maclock" "$emulator" "${PERF:-0}" | sudo tee "$INSTALL_STATE" >/dev/null
+}
+record_install
 
 # --- Done -----------------------------------------------------------------
 emit_gauge 100 "Done"

--- a/setup.sh
+++ b/setup.sh
@@ -609,14 +609,16 @@ current_timezone() {
 }
 
 pick_timezone() {
-  # zone1970.tab lists every Area/City tzdata knows, one per line
-  local tab=/usr/share/zoneinfo/zone1970.tab
-  [[ -f $tab ]] || tab=/usr/share/zoneinfo/zone.tab
+  # zone.tab, not zone1970.tab: the latter folds Oslo, Stockholm, Amsterdam
+  # and a hundred others into one zone each, and nobody will find their
+  # city under Berlin. raspi-config reads the same table.
+  local tab=/usr/share/zoneinfo/zone.tab
+  [[ -f $tab ]] || tab=/usr/share/zoneinfo/zone1970.tab
   [[ -f $tab ]] || die "No tzdata zone table at /usr/share/zoneinfo"
   local areas=() cities=() item area city
   while read -r item; do areas+=("$item" ""); done \
     < <(awk -F'\t' '!/^#/ { split($3, p, "/"); print p[1] }' "$tab" | sort -u)
-  area=$(wt_menu "Timezone" "The Pi is on UTC. Pick your area:" "${areas[0]}" 12 "${areas[@]}") \
+  area=$(wt_menu "Timezone" "Pick your area:" "${areas[0]}" 12 "${areas[@]}") \
     || return 1
   while read -r item; do cities+=("$item" ""); done \
     < <(awk -F'\t' -v a="$area/" '!/^#/ && index($3, a) == 1 { print substr($3, length(a) + 1) }' "$tab" | sort)
@@ -625,14 +627,26 @@ pick_timezone() {
   TIMEZONE="$area/$city"
 }
 
+if [[ -n $TIMEZONE && ! -f /usr/share/zoneinfo/$TIMEZONE ]]; then
+  die "Unknown timezone: $TIMEZONE (see: timedatectl list-timezones)"
+fi
 if [[ $INSTALL_MACLOCK -eq 1 ]]; then
   if [[ -z $NIGHT_DIM ]]; then
     cur=No; [[ $(conf_get NIGHT_DIM) == 1 ]] && cur=Yes
-    NIGHT_CHOICE=$(wt_menu "Night Dimming" "" "$cur" 2 \
-      "Yes"  "Dim the screen at sunset, dark from 10pm, back at sunrise" \
-      "No"   "Leave brightness to the dial") || die "Cancelled"
-    case "$NIGHT_CHOICE" in Yes) NIGHT_DIM=1 ;; No) NIGHT_DIM=0 ;; esac
+    tz=${TIMEZONE:-$(current_timezone || echo "not set")}
+    # Stock Pi OS images ship Europe/London, so a zone that looks set may
+    # not be. Show it and offer the picker either way.
+    NIGHT_CHOICE=$(wt_menu "Night Dimming" "Sunset to sunrise the screen dims; from 10pm it goes dark." "$cur" 3 \
+      "Yes"       "Follow the sun for the timezone: $tz" \
+      "Timezone"  "Same, but pick the timezone first" \
+      "No"        "Leave brightness to the dial") || die "Cancelled"
+    case "$NIGHT_CHOICE" in
+      Yes)      NIGHT_DIM=1 ;;
+      Timezone) NIGHT_DIM=1; pick_timezone || die "Cancelled" ;;
+      No)       NIGHT_DIM=0 ;;
+    esac
   fi
+  # The schedule needs a real zone: UTC has no reference city
   if [[ $NIGHT_DIM -eq 1 && -z $TIMEZONE ]] && ! current_timezone >/dev/null; then
     pick_timezone || die "Cancelled"
   fi
@@ -644,7 +658,7 @@ TOTAL_STEPS=3   # apt update, apt install, patch_cmdline
 [[ $WIFI_POWERSAVE -eq 0 ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
 [[ -n $NEW_HOSTNAME && $NEW_HOSTNAME != "$CUR_HOSTNAME" ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
 [[ -n $TIMEZONE ]] && TOTAL_STEPS=$((TOTAL_STEPS+1))
-[[ $INSTALL_MACLOCK -eq 1 ]] && TOTAL_STEPS=$((TOTAL_STEPS+5))
+[[ $INSTALL_MACLOCK -eq 1 ]] && TOTAL_STEPS=$((TOTAL_STEPS+6))
 if [[ $INSTALL_SHEEPSHAVER -eq 1 ]]; then
   if [[ -x /usr/local/bin/SheepShaver ]]; then
     TOTAL_STEPS=$((TOTAL_STEPS+9))
@@ -710,7 +724,6 @@ fi
 
 # --- Timezone -------------------------------------------------------------
 if [[ -n $TIMEZONE ]]; then
-  [[ -f /usr/share/zoneinfo/$TIMEZONE ]] || die "Unknown timezone: $TIMEZONE"
   run "Setting timezone: $TIMEZONE" sudo timedatectl set-timezone "$TIMEZONE"
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -713,7 +713,8 @@ Useful if your Macintosh Mini is a desk accessory or display piece." "$cur" 3 \
       00:00) cur="12 AM" ;; 01:00) cur="1 AM" ;;
       *) if grep -q '^NIGHT_OFF_AT=$' "$NIGHT_CONF" 2>/dev/null; then cur=Never; else cur="10 PM"; fi ;;
     esac
-    OFF_CHOICE=$(wt_menu "Night Dimming" "Do you want your screen to turn off at night (until 1 hour before sunrise)?" "$cur" 6 \
+    OFF_CHOICE=$(wt_menu "Night Dimming" "Do you want your screen to turn off at night?
+(It comes back on 1 hour before sunrise.)" "$cur" 6 \
       "Never" "" "9 PM" "" "10 PM" "" "11 PM" "" "12 AM" "" "1 AM" "") || die "Cancelled"
     case "$OFF_CHOICE" in
       Never)   NIGHT_OFF=never ;;


### PR DESCRIPTION
Sunset to sunrise the backlight runs at half the dial level, goes fully dark from a chosen time (default 10 PM) until an hour before sunrise, and comes back to the dial level at sunrise. Turning the dial at night wakes the screen until the next sunset. Scheduled changes fade over 30 s; a dial wake uses the dial's own quick ramp.

## How it finds sunrise

Computed on the Pi, offline, for the reference city of the system timezone (coordinates from tzdata's zone tables). `LAT`/`LON` in `/etc/default/brightness-control` override that for a closer fix. The schedule works from the most recent sunrise and sunset instants, so it holds where the clock runs far from the sun (Alaska, UTC+14) and at high latitudes where the cutoff comes before sunset (dark from sunset). Polar night dims only. The schedule waits for NTP because the Zero has no clock battery, and a bad config value logs and disables dimming rather than crash-looping the service.

## Installer (v1.2.0)

- **Update-aware.** A re-run on an existing install opens with *Update to version 1.2.0* / *Update and edit settings* / *Exit*. Update keeps every setting and asks nothing. Edit walks the prompts with current values as defaults. State lives in `/etc/macintosh-mini.conf`; pre-1.2.0 installs are recognised from the brightness service file and the autostart markers in `~/.profile`.
- **Night Dimming prompt**: "Do you want your screen to dim automatically from sunset to sunrise?" with *Yes (timezone: X)* / *Update timezone* / *No*. Stock images ship Europe/London, so the zone is shown. If the Pi is on UTC the raspi-config style area/city picker runs regardless, reading `zone.tab` so Oslo, Amsterdam and the rest are offered.
- **Screen-off prompt**: Never, 9 PM through 1 AM.
- Flags for unattended runs: `--night-dim` / `--no-night-dim`, `--night-off never|HH:MM`, `--timezone Area/City`, `--branch` (fetch helper files from an unmerged branch).
- Gauge says it will take a while and that the Pi reboots itself.
- The brightness service is restarted on update (`start` was a no-op on a running service, so updated scripts never ran until reboot). Maclock gauge step count corrected.

## Config

`/etc/default/brightness-control`, read by the unit via `EnvironmentFile`:

```
NIGHT_DIM=1
LAT=
LON=
NIGHT_FACTOR=0.5
NIGHT_OFF_AT=22:00
```

## Testing

- 37 unit tests in `maclock-build/test_brightness_control.py` (`python3 -m unittest test_brightness_control`). Sun times within 1 minute of NOAA for New York, London, Sydney. Real-sun cases: Stockholm midsummer, Nome and Reykjavik (sunset after midnight), Kiritimati, Tromsø in both seasons and on the first day of each polar stretch, and the hour-before-sunrise wake.
- Stubbed-hardware run of the main loop: schedule reaches the PWM duty file, dial wakes the screen, next sunset dims again.
- Installer config writer and install-state recording exercised in a sandbox under `set -euo pipefail`.
- Installed on a Pi Zero 2 W via `--branch` and confirmed dimming, cutoff, and dial wake. The update menu, new prompts, and the hour-before-sunrise change came after that run and want one more pass on hardware.